### PR TITLE
ENH: Use large_image for NDPI, etc., not just SVS files

### DIFF
--- a/histomics_stream/__init__.py
+++ b/histomics_stream/__init__.py
@@ -1,6 +1,6 @@
 """Whole-slide image streamer for TensorFlow."""
 
-__version__ = "2.2.2"
+__version__ = "2.2.3"
 
 """
 

--- a/histomics_stream/configure.py
+++ b/histomics_stream/configure.py
@@ -105,7 +105,7 @@ class FindResolutionForSlide:
         filename = slide["filename"]
 
         # Do the work.
-        if re.compile(r"\.svs$").search(filename):
+        if not re.compile(r"\.zarr$").search(filename):
             import large_image
 
             # read whole-slide image file and create large_image object
@@ -202,7 +202,7 @@ class FindResolutionForSlide:
                     / read_magnification
                 )
 
-        elif re.compile(r"\.zarr$").search(filename):
+        else:
             import zarr
             import openslide as os
 
@@ -252,21 +252,6 @@ class FindResolutionForSlide:
                 raise ValueError(
                     f"Couldn't find magnification {self.target_magnification}X in Zarr storage."
                 )
-
-        else:
-            from PIL import Image
-
-            # We don't know magnifications so assume reasonable values
-            level = 0
-            slide["target_magnification"] = self.target_magnification
-            slide["scan_magnification"] = None
-            slide["read_magnification"] = None
-            slide["returned_magnification"] = None
-
-            pil_obj = Image.open(filename)
-            #  (Note that number_pixel_columns_for_slide is before
-            #  number_pixel_rows_for_slide)
-            number_pixel_columns_for_slide, number_pixel_rows_for_slide = pil_obj.size
 
         slide["level"] = level
         # Note that slide size is defined by the requested magnification, which may not

--- a/histomics_stream/tensorflow.py
+++ b/histomics_stream/tensorflow.py
@@ -349,28 +349,20 @@ class CreateTensorFlowDataset:
         chunk_right = math.floor(chunk_right.numpy() / factor.numpy() + 0.01)
         returned_magnification = returned_magnification.numpy()
 
-        if re.compile(r"\.svs$").search(filename):
-            import large_image
+        import large_image
 
-            ts = large_image.open(filename)
-            chunk = ts.getRegion(
-                scale=dict(magnification=returned_magnification),
-                format=large_image.constants.TILE_FORMAT_NUMPY,
-                region=dict(
-                    left=chunk_left,
-                    top=chunk_top,
-                    width=chunk_right - chunk_left,
-                    height=chunk_bottom - chunk_top,
-                    units="mag_pixels",
-                ),
-            )[0]
-        else:
-            from PIL import Image
-
-            pil_obj = Image.open(filename)
-            chunk = np.asarray(pil_obj)[
-                chunk_left:chunk_right, chunk_top:chunk_bottom, :
-            ]
+        ts = large_image.open(filename)
+        chunk = ts.getRegion(
+            scale=dict(magnification=returned_magnification),
+            format=large_image.constants.TILE_FORMAT_NUMPY,
+            region=dict(
+                left=chunk_left,
+                top=chunk_top,
+                width=chunk_right - chunk_left,
+                height=chunk_bottom - chunk_top,
+                units="mag_pixels",
+            ),
+        )[0]
 
         # Do we want to support other than RGB and/or other than uint8?!!!
         return tf.convert_to_tensor(chunk[..., :3], dtype=tf.uint8)


### PR DESCRIPTION
Handle not just SVS, but  now all image formats except ZARR, via `large_image`.  Previously `PIL` was handling everything but SVS and ZARR.