### PR TITLE
Large image

### DIFF
--- a/example/tensorflow_stream.ipynb
+++ b/example/tensorflow_stream.ipynb
@@ -19,7 +19,7 @@
    "source": [
     "## Installation\n",
     "\n",
-    "If you are running this notebook on Google Colab or another system where `histomics_stream` and its dependencies are not yet installed then they can be installed with the following commands."
+    "If you are running this notebook on Google Colab or another system where `histomics_stream` and its dependencies are not yet installed then they can be installed with the following commands.  Note that image readers in addition to openslide are also supported by using, e.g., `large_image[openslide,ometiff,openjpeg,bioformats]` on the below pip install command line."
    ]
   },
   {
@@ -32,7 +32,7 @@
     "!apt update\n",
     "!apt install -y python3-openslide openslide-tools\n",
     "\n",
-    "!pip install histomics_stream histomics_detect 'large_image[openslide,ometiff,openjpeg,bioformats]' pooch scikit_image --find-links https://girder.github.io/large_image_wheels\n",
+    "!pip install histomics_stream histomics_detect 'large_image[openslide]' pooch scikit_image --find-links https://girder.github.io/large_image_wheels\n",
     "\n",
     "print(\n",
     "    \"\\nNOTE!: On Google Colab you may need to choose 'Runtime->Restart runtime' for these updates to take effect.\"\n",

--- a/histomics_stream/__init__.py
+++ b/histomics_stream/__init__.py
@@ -1,6 +1,6 @@
 """Whole-slide image streamer for TensorFlow."""
 
-__version__ = "2.2.3"
+__version__ = "2.2.4"
 
 """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,6 @@ dependencies = [
     "imagecodecs",
     "itk",
     "numpy",
-    "openslide-python",
-    "pillow",
     "zarr",
 ]
 dynamic = ["version", "description"]


### PR DESCRIPTION
Although they can be useful for other examples, in this example we need only `large_image[openslide]`, not the full `large_image[openslide,ometiff,openjpeg,bioformats]`.

Also, `histomics_stream` does not need the direct python dependency `openslide-python` because the needed functionality is installed in via `large_image[openslide]`.