### PR TITLE
DOC: Show internals, image in tensorflow_stream.ipynb

### DIFF
--- a/example/tensorflow_stream.ipynb
+++ b/example/tensorflow_stream.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "20e79577",
+   "id": "d64ab87a",
    "metadata": {},
    "source": [
     "# Demonstration of histomics_stream\n",
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23dde247",
+   "id": "1b31e90e",
    "metadata": {},
    "source": [
     "## Installation\n",
@@ -24,15 +24,235 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "91160fb5",
+   "execution_count": 1,
+   "id": "55227bac",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hit:1 http://security.ubuntu.com/ubuntu bionic-security InRelease\n",
+      "Hit:2 https://deb.nodesource.com/node_16.x bionic InRelease                    \u001b[0m\n",
+      "Ign:3 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease\n",
+      "Ign:4 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  InRelease\n",
+      "Hit:5 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  Release\n",
+      "Hit:6 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  Release\n",
+      "Hit:7 http://archive.ubuntu.com/ubuntu bionic InRelease\n",
+      "Hit:8 http://archive.ubuntu.com/ubuntu bionic-updates InRelease\n",
+      "Hit:9 http://archive.ubuntu.com/ubuntu bionic-backports InRelease\n",
+      "Reading package lists... Done\u001b[0m\u001b[33m\u001b[33m\u001b[33m\u001b[33m\u001b[33m\u001b[33m\u001b[33m\n",
+      "Building dependency tree       \n",
+      "Reading state information... Done\n",
+      "48 packages can be upgraded. Run 'apt list --upgradable' to see them.\n",
+      "Reading package lists... Done\n",
+      "Building dependency tree       \n",
+      "Reading state information... Done\n",
+      "python3-openslide is already the newest version (1.1.1-2ubuntu4).\n",
+      "Suggested packages:\n",
+      "  libtiff-tools\n",
+      "The following NEW packages will be installed:\n",
+      "  openslide-tools\n",
+      "0 upgraded, 1 newly installed, 0 to remove and 48 not upgraded.\n",
+      "Need to get 12.7 kB of archives.\n",
+      "After this operation, 57.3 kB of additional disk space will be used.\n",
+      "Get:1 http://archive.ubuntu.com/ubuntu bionic/universe amd64 openslide-tools amd64 3.4.1+dfsg-2 [12.7 kB]\n",
+      "Fetched 12.7 kB in 0s (185 kB/s)            \u001b[0m\u001b[33m\n",
+      "debconf: delaying package configuration, since apt-utils is not installed\n",
+      "\n",
+      "\u001b7\u001b[0;23r\u001b8\u001b[1ASelecting previously unselected package openslide-tools.\n",
+      "(Reading database ... 46432 files and directories currently installed.)\n",
+      "Preparing to unpack .../openslide-tools_3.4.1+dfsg-2_amd64.deb ...\n",
+      "\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [  0%]\u001b[49m\u001b[39m [..........................................................] \u001b8\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [ 17%]\u001b[49m\u001b[39m [#########.................................................] \u001b8Unpacking openslide-tools (3.4.1+dfsg-2) ...\n",
+      "\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [ 33%]\u001b[49m\u001b[39m [###################.......................................] \u001b8\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [ 50%]\u001b[49m\u001b[39m [#############################.............................] \u001b8Setting up openslide-tools (3.4.1+dfsg-2) ...\n",
+      "\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [ 67%]\u001b[49m\u001b[39m [######################################....................] \u001b8\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [ 83%]\u001b[49m\u001b[39m [################################################..........] \u001b8\n",
+      "\u001b7\u001b[0;24r\u001b8\u001b[1A\u001b[JLooking in links: https://girder.github.io/large_image_wheels\n",
+      "Requirement already satisfied: large_image[openslide] in /usr/local/lib/python3.7/dist-packages (1.12.0)\n",
+      "Requirement already satisfied: Pillow in /usr/local/lib/python3.7/dist-packages (from large_image[openslide]) (9.0.1)\n",
+      "Requirement already satisfied: psutil>=4.2.0 in /usr/local/lib/python3.7/dist-packages (from large_image[openslide]) (5.9.0)\n",
+      "Requirement already satisfied: importlib-metadata in /usr/local/lib/python3.7/dist-packages (from large_image[openslide]) (4.11.3)\n",
+      "Requirement already satisfied: numpy>=1.10.4 in /usr/local/lib/python3.7/dist-packages (from large_image[openslide]) (1.21.5)\n",
+      "Requirement already satisfied: cachetools>=3.0.0 in /usr/local/lib/python3.7/dist-packages (from large_image[openslide]) (5.0.0)\n",
+      "Requirement already satisfied: palettable in /usr/local/lib/python3.7/dist-packages (from large_image[openslide]) (3.3.0)\n",
+      "Requirement already satisfied: large-image-source-openslide in /usr/local/lib/python3.7/dist-packages (from large_image[openslide]) (1.12.0)\n",
+      "Requirement already satisfied: typing-extensions>=3.6.4 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata->large_image[openslide]) (4.1.1)\n",
+      "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata->large_image[openslide]) (3.7.0)\n",
+      "Requirement already satisfied: tifftools>=1.2.0 in /usr/local/lib/python3.7/dist-packages (from large-image-source-openslide->large_image[openslide]) (1.2.10)\n",
+      "Requirement already satisfied: openslide-python>=1.1.0 in /usr/local/lib/python3.7/dist-packages (from large-image-source-openslide->large_image[openslide]) (1.1.2)\n",
+      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\u001b[0m\u001b[33m\n",
+      "\u001b[0mCollecting histomics_stream\n",
+      "  Downloading histomics_stream-2.2.3-py3-none-any.whl (21 kB)\n",
+      "Requirement already satisfied: openslide-python in /usr/local/lib/python3.7/dist-packages (from histomics_stream) (1.1.2)\n",
+      "Requirement already satisfied: zarr in /usr/local/lib/python3.7/dist-packages (from histomics_stream) (2.11.1)\n",
+      "Requirement already satisfied: itk in /usr/local/lib/python3.7/dist-packages (from histomics_stream) (5.2.1.post1)\n",
+      "Requirement already satisfied: pillow in /usr/local/lib/python3.7/dist-packages (from histomics_stream) (9.0.1)\n",
+      "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from histomics_stream) (1.21.5)\n",
+      "Requirement already satisfied: imagecodecs in /usr/local/lib/python3.7/dist-packages (from histomics_stream) (2021.11.20)\n",
+      "Requirement already satisfied: itk-io==5.2.1.post1 in /usr/local/lib/python3.7/dist-packages (from itk->histomics_stream) (5.2.1.post1)\n",
+      "Requirement already satisfied: itk-segmentation==5.2.1.post1 in /usr/local/lib/python3.7/dist-packages (from itk->histomics_stream) (5.2.1.post1)\n",
+      "Requirement already satisfied: itk-filtering==5.2.1.post1 in /usr/local/lib/python3.7/dist-packages (from itk->histomics_stream) (5.2.1.post1)\n",
+      "Requirement already satisfied: itk-numerics==5.2.1.post1 in /usr/local/lib/python3.7/dist-packages (from itk->histomics_stream) (5.2.1.post1)\n",
+      "Requirement already satisfied: itk-core==5.2.1.post1 in /usr/local/lib/python3.7/dist-packages (from itk->histomics_stream) (5.2.1.post1)\n",
+      "Requirement already satisfied: itk-registration==5.2.1.post1 in /usr/local/lib/python3.7/dist-packages (from itk->histomics_stream) (5.2.1.post1)\n",
+      "Requirement already satisfied: fasteners in /usr/local/lib/python3.7/dist-packages (from zarr->histomics_stream) (0.17.3)\n",
+      "Requirement already satisfied: asciitree in /usr/local/lib/python3.7/dist-packages (from zarr->histomics_stream) (0.3.3)\n",
+      "Requirement already satisfied: numcodecs>=0.6.4 in /usr/local/lib/python3.7/dist-packages (from zarr->histomics_stream) (0.9.1)\n",
+      "Installing collected packages: histomics_stream\n",
+      "Successfully installed histomics_stream-2.2.3\n",
+      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\u001b[0m\u001b[33m\n",
+      "\u001b[0mCollecting histomics_detect\n",
+      "  Downloading histomics_detect-0.0.1-py3-none-any.whl (68 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m68.4/68.4 KB\u001b[0m \u001b[31m13.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hCollecting pooch\n",
+      "  Downloading pooch-1.6.0-py3-none-any.whl (56 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.3/56.3 KB\u001b[0m \u001b[31m11.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: itkwidgets in /usr/local/lib/python3.7/dist-packages (0.32.1)\n",
+      "Collecting pandas\n",
+      "  Downloading pandas-1.3.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (11.3 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m11.3/11.3 MB\u001b[0m \u001b[31m78.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from histomics_detect) (1.21.5)\n",
+      "Collecting pyyaml\n",
+      "  Downloading PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (596 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m596.3/596.3 KB\u001b[0m \u001b[31m41.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: scipy in /usr/local/lib/python3.7/dist-packages (from histomics_detect) (1.7.3)\n",
+      "Requirement already satisfied: tensorflow-gpu>=2.4 in /usr/local/lib/python3.7/dist-packages (from histomics_detect) (2.8.0)\n",
+      "Requirement already satisfied: matplotlib in /usr/local/lib/python3.7/dist-packages (from histomics_detect) (3.5.1)\n",
+      "Requirement already satisfied: Pillow in /usr/local/lib/python3.7/dist-packages (from histomics_detect) (9.0.1)\n",
+      "Collecting appdirs>=1.3.0\n",
+      "  Downloading appdirs-1.4.4-py2.py3-none-any.whl (9.6 kB)\n",
+      "Requirement already satisfied: packaging>=20.0 in /usr/local/lib/python3.7/dist-packages (from pooch) (21.3)\n",
+      "Requirement already satisfied: requests>=2.19.0 in /usr/local/lib/python3.7/dist-packages (from pooch) (2.27.1)\n",
+      "Requirement already satisfied: zstandard in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (0.17.0)\n",
+      "Requirement already satisfied: ipydatawidgets>=4.0.1 in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (4.2.0)\n",
+      "Requirement already satisfied: ipywidgets>=7.5.1 in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (7.7.0)\n",
+      "Requirement already satisfied: six in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (1.16.0)\n",
+      "Requirement already satisfied: ipympl>=0.4.1 in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (0.8.8)\n",
+      "Requirement already satisfied: colorcet in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (3.0.0)\n",
+      "Requirement already satisfied: itk-meshtopolydata>=0.7.1 in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (0.7.1)\n",
+      "Requirement already satisfied: itk-core>=5.2.0.post2 in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (5.2.1.post1)\n",
+      "Requirement already satisfied: itk-filtering>=5.2.0.post2 in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (5.2.1.post1)\n",
+      "Requirement already satisfied: traittypes>=0.2.0 in /usr/local/lib/python3.7/dist-packages (from ipydatawidgets>=4.0.1->itkwidgets) (0.2.1)\n",
+      "Requirement already satisfied: ipython<9 in /usr/local/lib/python3.7/dist-packages (from ipympl>=0.4.1->itkwidgets) (7.32.0)\n",
+      "Requirement already satisfied: ipython-genutils in /usr/local/lib/python3.7/dist-packages (from ipympl>=0.4.1->itkwidgets) (0.2.0)\n",
+      "Requirement already satisfied: traitlets<6 in /usr/local/lib/python3.7/dist-packages (from ipympl>=0.4.1->itkwidgets) (5.1.1)\n",
+      "Requirement already satisfied: nbformat>=4.2.0 in /usr/local/lib/python3.7/dist-packages (from ipywidgets>=7.5.1->itkwidgets) (5.2.0)\n",
+      "Requirement already satisfied: jupyterlab-widgets>=1.0.0 in /usr/local/lib/python3.7/dist-packages (from ipywidgets>=7.5.1->itkwidgets) (1.1.0)\n",
+      "Requirement already satisfied: ipykernel>=4.5.1 in /usr/local/lib/python3.7/dist-packages (from ipywidgets>=7.5.1->itkwidgets) (6.9.2)\n",
+      "Requirement already satisfied: widgetsnbextension~=3.6.0 in /usr/local/lib/python3.7/dist-packages (from ipywidgets>=7.5.1->itkwidgets) (3.6.0)\n",
+      "Requirement already satisfied: itk-numerics==5.2.1.post1 in /usr/local/lib/python3.7/dist-packages (from itk-filtering>=5.2.0.post2->itkwidgets) (5.2.1.post1)\n",
+      "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib->histomics_detect) (1.4.0)\n",
+      "Requirement already satisfied: python-dateutil>=2.7 in /usr/local/lib/python3.7/dist-packages (from matplotlib->histomics_detect) (2.8.2)\n",
+      "Requirement already satisfied: fonttools>=4.22.0 in /usr/local/lib/python3.7/dist-packages (from matplotlib->histomics_detect) (4.31.2)\n",
+      "Requirement already satisfied: pyparsing>=2.2.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib->histomics_detect) (3.0.7)\n",
+      "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.7/dist-packages (from matplotlib->histomics_detect) (0.11.0)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.7/dist-packages (from requests>=2.19.0->pooch) (2021.10.8)\n",
+      "Requirement already satisfied: charset-normalizer~=2.0.0 in /usr/local/lib/python3.7/dist-packages (from requests>=2.19.0->pooch) (2.0.12)\n",
+      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /usr/local/lib/python3.7/dist-packages (from requests>=2.19.0->pooch) (1.26.9)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /usr/lib/python3/dist-packages (from requests>=2.19.0->pooch) (2.6)\n",
+      "Requirement already satisfied: grpcio<2.0,>=1.24.3 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (1.44.0)\n",
+      "Requirement already satisfied: absl-py>=0.4.0 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (1.0.0)\n",
+      "Requirement already satisfied: tf-estimator-nightly==2.8.0.dev2021122109 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (2.8.0.dev2021122109)\n",
+      "Requirement already satisfied: astunparse>=1.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (1.6.3)\n",
+      "Requirement already satisfied: libclang>=9.0.1 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (13.0.0)\n",
+      "Requirement already satisfied: wrapt>=1.11.0 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (1.14.0)\n",
+      "Requirement already satisfied: keras-preprocessing>=1.1.1 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (1.1.2)\n",
+      "Requirement already satisfied: termcolor>=1.1.0 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (1.1.0)\n",
+      "Requirement already satisfied: protobuf>=3.9.2 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (3.19.4)\n",
+      "Requirement already satisfied: google-pasta>=0.1.1 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (0.2.0)\n",
+      "Requirement already satisfied: gast>=0.2.1 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (0.5.3)\n",
+      "Requirement already satisfied: flatbuffers>=1.12 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (2.0)\n",
+      "Requirement already satisfied: setuptools in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (60.10.0)\n",
+      "Requirement already satisfied: opt-einsum>=2.3.2 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (3.3.0)\n",
+      "Requirement already satisfied: tensorboard<2.9,>=2.8 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (2.8.0)\n",
+      "Requirement already satisfied: tensorflow-io-gcs-filesystem>=0.23.1 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (0.24.0)\n",
+      "Requirement already satisfied: keras<2.9,>=2.8.0rc0 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (2.8.0)\n",
+      "Requirement already satisfied: h5py>=2.9.0 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (3.6.0)\n",
+      "Requirement already satisfied: typing-extensions>=3.6.6 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (4.1.1)\n",
+      "Requirement already satisfied: param>=1.7.0 in /usr/local/lib/python3.7/dist-packages (from colorcet->itkwidgets) (1.12.0)\n",
+      "Requirement already satisfied: pyct>=0.4.4 in /usr/local/lib/python3.7/dist-packages (from colorcet->itkwidgets) (0.4.8)\n",
+      "Collecting pytz>=2017.3\n",
+      "  Downloading pytz-2022.1-py2.py3-none-any.whl (503 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m503.5/503.5 KB\u001b[0m \u001b[31m44.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: wheel<1.0,>=0.23.0 in /usr/local/lib/python3.7/dist-packages (from astunparse>=1.6.0->tensorflow-gpu>=2.4->histomics_detect) (0.37.1)\n",
+      "Requirement already satisfied: cached-property in /usr/local/lib/python3.7/dist-packages (from h5py>=2.9.0->tensorflow-gpu>=2.4->histomics_detect) (1.5.2)\n",
+      "Requirement already satisfied: psutil in /usr/local/lib/python3.7/dist-packages (from ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (5.9.0)\n",
+      "Requirement already satisfied: jupyter-client<8.0 in /usr/local/lib/python3.7/dist-packages (from ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (7.1.2)\n",
+      "Requirement already satisfied: matplotlib-inline<0.2.0,>=0.1.0 in /usr/local/lib/python3.7/dist-packages (from ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (0.1.3)\n",
+      "Requirement already satisfied: nest-asyncio in /usr/local/lib/python3.7/dist-packages (from ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (1.5.4)\n",
+      "Requirement already satisfied: tornado<7.0,>=4.2 in /usr/local/lib/python3.7/dist-packages (from ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (6.1)\n",
+      "Requirement already satisfied: debugpy<2.0,>=1.0.0 in /usr/local/lib/python3.7/dist-packages (from ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (1.5.1)\n",
+      "Requirement already satisfied: pickleshare in /usr/local/lib/python3.7/dist-packages (from ipython<9->ipympl>=0.4.1->itkwidgets) (0.7.5)\n",
+      "Requirement already satisfied: decorator in /usr/local/lib/python3.7/dist-packages (from ipython<9->ipympl>=0.4.1->itkwidgets) (5.1.1)\n",
+      "Requirement already satisfied: pygments in /usr/local/lib/python3.7/dist-packages (from ipython<9->ipympl>=0.4.1->itkwidgets) (2.11.2)\n",
+      "Requirement already satisfied: backcall in /usr/local/lib/python3.7/dist-packages (from ipython<9->ipympl>=0.4.1->itkwidgets) (0.2.0)\n",
+      "Requirement already satisfied: pexpect>4.3 in /usr/local/lib/python3.7/dist-packages (from ipython<9->ipympl>=0.4.1->itkwidgets) (4.8.0)\n",
+      "Requirement already satisfied: jedi>=0.16 in /usr/local/lib/python3.7/dist-packages (from ipython<9->ipympl>=0.4.1->itkwidgets) (0.18.1)\n",
+      "Requirement already satisfied: prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0 in /usr/local/lib/python3.7/dist-packages (from ipython<9->ipympl>=0.4.1->itkwidgets) (3.0.28)\n",
+      "Requirement already satisfied: jupyter-core in /usr/local/lib/python3.7/dist-packages (from nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (4.9.2)\n",
+      "Requirement already satisfied: jsonschema!=2.5.0,>=2.4 in /usr/local/lib/python3.7/dist-packages (from nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (4.4.0)\n",
+      "Requirement already satisfied: markdown>=2.6.8 in /usr/local/lib/python3.7/dist-packages (from tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (3.3.6)\n",
+      "Requirement already satisfied: google-auth-oauthlib<0.5,>=0.4.1 in /usr/local/lib/python3.7/dist-packages (from tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (0.4.6)\n",
+      "Requirement already satisfied: google-auth<3,>=1.6.3 in /usr/local/lib/python3.7/dist-packages (from tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (2.6.2)\n",
+      "Requirement already satisfied: werkzeug>=0.11.15 in /usr/local/lib/python3.7/dist-packages (from tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (2.0.3)\n",
+      "Requirement already satisfied: tensorboard-plugin-wit>=1.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (1.8.1)\n",
+      "Requirement already satisfied: tensorboard-data-server<0.7.0,>=0.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (0.6.1)\n",
+      "Requirement already satisfied: notebook>=4.4.1 in /usr/local/lib/python3.7/dist-packages (from widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (6.4.10)\n",
+      "Requirement already satisfied: cachetools<6.0,>=2.0.0 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (5.0.0)\n",
+      "Requirement already satisfied: rsa<5,>=3.1.4 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (4.8)\n",
+      "Requirement already satisfied: pyasn1-modules>=0.2.1 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (0.2.8)\n",
+      "Requirement already satisfied: requests-oauthlib>=0.7.0 in /usr/local/lib/python3.7/dist-packages (from google-auth-oauthlib<0.5,>=0.4.1->tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (1.3.1)\n",
+      "Requirement already satisfied: parso<0.9.0,>=0.8.0 in /usr/local/lib/python3.7/dist-packages (from jedi>=0.16->ipython<9->ipympl>=0.4.1->itkwidgets) (0.8.3)\n",
+      "Requirement already satisfied: importlib-resources>=1.4.0 in /usr/local/lib/python3.7/dist-packages (from jsonschema!=2.5.0,>=2.4->nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (5.4.0)\n",
+      "Requirement already satisfied: pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 in /usr/local/lib/python3.7/dist-packages (from jsonschema!=2.5.0,>=2.4->nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (0.18.1)\n",
+      "Requirement already satisfied: attrs>=17.4.0 in /usr/local/lib/python3.7/dist-packages (from jsonschema!=2.5.0,>=2.4->nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (21.4.0)\n",
+      "Requirement already satisfied: importlib-metadata in /usr/local/lib/python3.7/dist-packages (from jsonschema!=2.5.0,>=2.4->nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (4.11.3)\n",
+      "Requirement already satisfied: entrypoints in /usr/local/lib/python3.7/dist-packages (from jupyter-client<8.0->ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (0.4)\n",
+      "Requirement already satisfied: pyzmq>=13 in /usr/local/lib/python3.7/dist-packages (from jupyter-client<8.0->ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (22.3.0)\n",
+      "Requirement already satisfied: argon2-cffi in /usr/local/lib/python3.7/dist-packages (from notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (21.3.0)\n",
+      "Requirement already satisfied: jinja2 in /usr/local/lib/python3.7/dist-packages (from notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (3.0.3)\n",
+      "Requirement already satisfied: nbconvert>=5 in /usr/local/lib/python3.7/dist-packages (from notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (6.4.4)\n",
+      "Requirement already satisfied: Send2Trash>=1.8.0 in /usr/local/lib/python3.7/dist-packages (from notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (1.8.0)\n",
+      "Requirement already satisfied: terminado>=0.8.3 in /usr/local/lib/python3.7/dist-packages (from notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (0.13.3)\n",
+      "Requirement already satisfied: prometheus-client in /usr/local/lib/python3.7/dist-packages (from notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (0.13.1)\n",
+      "Requirement already satisfied: ptyprocess>=0.5 in /usr/local/lib/python3.7/dist-packages (from pexpect>4.3->ipython<9->ipympl>=0.4.1->itkwidgets) (0.7.0)\n",
+      "Requirement already satisfied: wcwidth in /usr/local/lib/python3.7/dist-packages (from prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0->ipython<9->ipympl>=0.4.1->itkwidgets) (0.2.5)\n",
+      "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata->jsonschema!=2.5.0,>=2.4->nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (3.7.0)\n",
+      "Requirement already satisfied: testpath in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (0.6.0)\n",
+      "Requirement already satisfied: bleach in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (4.1.0)\n",
+      "Requirement already satisfied: nbclient<0.6.0,>=0.5.0 in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (0.5.13)\n",
+      "Requirement already satisfied: defusedxml in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (0.7.1)\n",
+      "Requirement already satisfied: jupyterlab-pygments in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (0.1.2)\n",
+      "Requirement already satisfied: beautifulsoup4 in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (4.10.0)\n",
+      "Requirement already satisfied: mistune<2,>=0.8.1 in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (0.8.4)\n",
+      "Requirement already satisfied: pandocfilters>=1.4.1 in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (1.5.0)\n",
+      "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.7/dist-packages (from jinja2->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (2.1.1)\n",
+      "Requirement already satisfied: pyasn1<0.5.0,>=0.4.6 in /usr/local/lib/python3.7/dist-packages (from pyasn1-modules>=0.2.1->google-auth<3,>=1.6.3->tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (0.4.8)\n",
+      "Requirement already satisfied: oauthlib>=3.0.0 in /usr/local/lib/python3.7/dist-packages (from requests-oauthlib>=0.7.0->google-auth-oauthlib<0.5,>=0.4.1->tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (3.2.0)\n",
+      "Requirement already satisfied: argon2-cffi-bindings in /usr/local/lib/python3.7/dist-packages (from argon2-cffi->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (21.2.0)\n",
+      "Requirement already satisfied: cffi>=1.0.1 in /usr/local/lib/python3.7/dist-packages (from argon2-cffi-bindings->argon2-cffi->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (1.15.0)\n",
+      "Requirement already satisfied: soupsieve>1.2 in /usr/local/lib/python3.7/dist-packages (from beautifulsoup4->nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (2.3.1)\n",
+      "Requirement already satisfied: webencodings in /usr/local/lib/python3.7/dist-packages (from bleach->nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (0.5.1)\n",
+      "Requirement already satisfied: pycparser in /usr/local/lib/python3.7/dist-packages (from cffi>=1.0.1->argon2-cffi-bindings->argon2-cffi->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (2.21)\n",
+      "Installing collected packages: pytz, appdirs, pyyaml, pooch, pandas, histomics_detect\n",
+      "Successfully installed appdirs-1.4.4 histomics_detect-0.0.1 pandas-1.3.5 pooch-1.6.0 pytz-2022.1 pyyaml-6.0\n",
+      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\u001b[0m\u001b[33m\n",
+      "\u001b[0mBuilding jupyterlab assets (build:prod:minimize)\n",
+      "\n",
+      "NOTE!: On Google Colab you may need to choose 'Runtime->Restart runtime' for these updates to take effect.\n"
+     ]
+    }
+   ],
    "source": [
+    "# Get histomics_stream and its dependencies\n",
     "!apt update\n",
     "!apt install -y python3-openslide openslide-tools\n",
+    "!pip install 'large_image[openslide]' --find-links https://girder.github.io/large_image_wheels\n",
+    "!pip install histomics_stream\n",
     "\n",
-    "!pip install histomics_stream histomics_detect 'large_image[openslide]' pooch scikit_image --find-links https://girder.github.io/large_image_wheels\n",
+    "# Get other packages used in this notebook\n",
+    "# N.B. itkwidgets works with jupyter<=3.0.0\n",
+    "!pip install histomics_detect pooch itkwidgets\n",
+    "!jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-matplotlib jupyterlab-datawidgets itkwidgets\n",
     "\n",
     "print(\n",
     "    \"\\nNOTE!: On Google Colab you may need to choose 'Runtime->Restart runtime' for these updates to take effect.\"\n",
@@ -41,7 +261,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a17363bf",
+   "id": "e07e30f1",
    "metadata": {},
    "source": [
     "## Fetching and creating the test data\n",
@@ -50,10 +270,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "885e1c2e",
+   "execution_count": 2,
+   "id": "d4c8ef2f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Downloading data from 'https://northwestern.box.com/shared/static/qelyzb45bigg6sqyumtj8kt2vwxztpzm' to file '/root/.cache/pooch/wsi/TCGA-AN-A0G0-01Z-00-DX1.svs'.\n",
+      "Downloading data from 'https://northwestern.box.com/shared/static/2q13q2r83avqjz9glrpt3s3nop6uhi2i' to file '/root/.cache/pooch/wsi/TCGA-AN-A0G0-01Z-00-DX1.mask.png'.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Have /root/.cache/pooch/wsi/TCGA-AN-A0G0-01Z-00-DX1.svs\n",
+      "Have /root/.cache/pooch/wsi/TCGA-AN-A0G0-01Z-00-DX1.mask.png\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "import pooch\n",
@@ -79,7 +316,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e94d0ccf",
+   "id": "41481d71",
    "metadata": {},
    "source": [
     "## Creating a study for use with histomics_stream\n",
@@ -91,10 +328,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "36e84032",
+   "execution_count": 3,
+   "id": "d249abdc",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Using python for large_image caching\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "my_study0 = {'version': 'version-1', 'number_pixel_rows_for_tile': 256, 'number_pixel_columns_for_tile': 256, 'slides': {'Slide_0': {'filename': '/root/.cache/pooch/wsi/TCGA-AN-A0G0-01Z-00-DX1.svs', 'slide_name': 'TCGA-AN-A0G0-01Z-00-DX1', 'slide_group': 'Group 3', 'number_pixel_rows_for_chunk': 2048, 'number_pixel_columns_for_chunk': 2048, 'target_magnification': 20.0, 'scan_magnification': 40.0, 'read_magnification': 40.0, 'returned_magnification': 40.0, 'level': 8, 'number_pixel_rows_for_slide': 20572, 'number_pixel_columns_for_slide': 27607}}}\n"
+     ]
+    }
+   ],
    "source": [
     "import histomics_stream as hs\n",
     "import tensorflow as tf\n",
@@ -126,7 +378,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2535ea27",
+   "id": "5c63d978",
    "metadata": {},
    "source": [
     "## Tile selection\n",
@@ -136,8 +388,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e9aaa456",
+   "execution_count": 4,
+   "id": "67c9acbc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,10 +398,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "07623cfe",
+   "execution_count": 5,
+   "id": "fed52e54",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "my_study_tiles_by_grid = {'version': 'version-1', 'number_pixel_rows_for_tile': 256, 'number_pixel_columns_for_tile': 256, 'slides': {'Slide_0': {'filename': '/root/.cache/pooch/wsi/TCGA-AN-A0G0-01Z-00-DX1.svs', 'slide_name': 'TCGA-AN-A0G0-01Z-00-DX1', 'slide_group': 'Group 3', 'number_pixel_rows_for_chunk': 2048, 'number_pixel_columns_for_chunk': 2048, 'target_magnification': 20.0, 'scan_magnification': 40.0, 'read_magnification': 40.0, 'returned_magnification': 40.0, 'level': 8, 'number_pixel_rows_for_slide': 20572, 'number_pixel_columns_for_slide': 27607, 'number_tile_rows_for_slide': 91, 'number_tile_columns_for_slide': 123, 'tiles': {'tile_4523': {'tile_top': 8064, 'tile_left': 21280}, 'tile_6445': {'tile_top': 11648, 'tile_left': 10976}, 'tile_7515': {'tile_top': 13664, 'tile_left': 2688}, 'tile_9840': {'tile_top': 17920, 'tile_left': 0}, 'tile_10972': {'tile_top': 19936, 'tile_left': 5600}}}}}\n"
+     ]
+    }
+   ],
    "source": [
     "# Demonstrate TilesByGridAndMask without a mask\n",
     "my_study_tiles_by_grid = copy.deepcopy(my_study0)\n",
@@ -168,10 +428,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "72e564b7",
+   "execution_count": 6,
+   "id": "4a469c81",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "my_study_tiles_by_grid_and_mask = {'version': 'version-1', 'number_pixel_rows_for_tile': 256, 'number_pixel_columns_for_tile': 256, 'slides': {'Slide_0': {'filename': '/root/.cache/pooch/wsi/TCGA-AN-A0G0-01Z-00-DX1.svs', 'slide_name': 'TCGA-AN-A0G0-01Z-00-DX1', 'slide_group': 'Group 3', 'number_pixel_rows_for_chunk': 2048, 'number_pixel_columns_for_chunk': 2048, 'target_magnification': 20.0, 'scan_magnification': 40.0, 'read_magnification': 40.0, 'returned_magnification': 40.0, 'level': 8, 'number_pixel_rows_for_slide': 20572, 'number_pixel_columns_for_slide': 27607, 'number_tile_rows_for_slide': 80, 'number_tile_columns_for_slide': 107, 'number_pixel_rows_for_mask': 642, 'number_pixel_columns_for_mask': 862, 'tiles': {'tile_3050': {'tile_top': 7168, 'tile_left': 13824}, 'tile_3412': {'tile_top': 7936, 'tile_left': 24320}, 'tile_3468': {'tile_top': 8192, 'tile_left': 11264}, 'tile_3698': {'tile_top': 8704, 'tile_left': 15360}, 'tile_4307': {'tile_top': 10240, 'tile_left': 6912}, 'tile_4460': {'tile_top': 10496, 'tile_left': 18688}, 'tile_5638': {'tile_top': 13312, 'tile_left': 18944}, 'tile_6916': {'tile_top': 16384, 'tile_left': 17408}, 'tile_7147': {'tile_top': 16896, 'tile_left': 21760}, 'tile_7575': {'tile_top': 17920, 'tile_left': 21760}}}}}\n"
+     ]
+    }
+   ],
    "source": [
     "# Demonstrate TilesByGridAndMask with a mask\n",
     "my_study_tiles_by_grid_and_mask = copy.deepcopy(my_study0)\n",
@@ -191,10 +459,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "560a32ef",
+   "execution_count": 7,
+   "id": "ee91ba28",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "my_study_tiles_by_list = {'version': 'version-1', 'number_pixel_rows_for_tile': 256, 'number_pixel_columns_for_tile': 256, 'slides': {'Slide_0': {'filename': '/root/.cache/pooch/wsi/TCGA-AN-A0G0-01Z-00-DX1.svs', 'slide_name': 'TCGA-AN-A0G0-01Z-00-DX1', 'slide_group': 'Group 3', 'number_pixel_rows_for_chunk': 2048, 'number_pixel_columns_for_chunk': 2048, 'target_magnification': 20.0, 'scan_magnification': 40.0, 'read_magnification': 40.0, 'returned_magnification': 40.0, 'level': 8, 'number_pixel_rows_for_slide': 20572, 'number_pixel_columns_for_slide': 27607, 'tiles': {'tile_4523': {'tile_top': 8064, 'tile_left': 21280}, 'tile_6445': {'tile_top': 11648, 'tile_left': 10976}, 'tile_7515': {'tile_top': 13664, 'tile_left': 2688}, 'tile_9840': {'tile_top': 17920, 'tile_left': 0}, 'tile_10972': {'tile_top': 19936, 'tile_left': 5600}}}}}\n"
+     ]
+    }
+   ],
    "source": [
     "# Demonstrate TilesByList\n",
     "my_study_tiles_by_list = copy.deepcopy(my_study0)\n",
@@ -212,10 +488,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f035365e",
+   "execution_count": 8,
+   "id": "3cc6010e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "my_study_tiles_randomly = {'version': 'version-1', 'number_pixel_rows_for_tile': 256, 'number_pixel_columns_for_tile': 256, 'slides': {'Slide_0': {'filename': '/root/.cache/pooch/wsi/TCGA-AN-A0G0-01Z-00-DX1.svs', 'slide_name': 'TCGA-AN-A0G0-01Z-00-DX1', 'slide_group': 'Group 3', 'number_pixel_rows_for_chunk': 2048, 'number_pixel_columns_for_chunk': 2048, 'target_magnification': 20.0, 'scan_magnification': 40.0, 'read_magnification': 40.0, 'returned_magnification': 40.0, 'level': 8, 'number_pixel_rows_for_slide': 20572, 'number_pixel_columns_for_slide': 27607, 'tiles': {'tile_0': {'tile_top': 10786, 'tile_left': 22964}, 'tile_1': {'tile_top': 7485, 'tile_left': 3533}, 'tile_2': {'tile_top': 19866, 'tile_left': 19454}, 'tile_3': {'tile_top': 15519, 'tile_left': 737}, 'tile_4': {'tile_top': 12588, 'tile_left': 16838}, 'tile_5': {'tile_top': 15907, 'tile_left': 619}, 'tile_6': {'tile_top': 214, 'tile_left': 16038}, 'tile_7': {'tile_top': 17510, 'tile_left': 13752}, 'tile_8': {'tile_top': 20204, 'tile_left': 26067}, 'tile_9': {'tile_top': 8053, 'tile_left': 42}}}}}\n"
+     ]
+    }
+   ],
    "source": [
     "# Demonstrate TilesRandomly\n",
     "my_study_tiles_randomly = copy.deepcopy(my_study0)\n",
@@ -229,7 +513,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1fadb2f1",
+   "id": "6f202811",
    "metadata": {},
    "source": [
     "## Creating a TensorFlow Dataset\n",
@@ -239,10 +523,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "020f9237",
+   "execution_count": 9,
+   "id": "bf4df44c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Finished selecting tiles.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-03-23 14:34:06.844953: I tensorflow/core/platform/cpu_feature_guard.cc:151] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F FMA\n",
+      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+      "2022-03-23 14:34:08.005244: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 9650 MB memory:  -> device: 0, name: GeForce RTX 2080 Ti, pci bus id: 0000:da:00.0, compute capability: 7.5\n",
+      "2022-03-23 14:34:08.007860: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:1 with 9650 MB memory:  -> device: 1, name: GeForce RTX 2080 Ti, pci bus id: 0000:db:00.0, compute capability: 7.5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Finished with CreateTensorFlowDataset\n",
+      "... with tile shape = (512, 512, 3)\n"
+     ]
+    }
+   ],
    "source": [
     "# Demonstrate TilesByGridAndMask with a mask\n",
     "my_study_of_tiles = copy.deepcopy(my_study0)\n",
@@ -266,7 +576,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90b2b623",
+   "id": "5c98ba65",
    "metadata": {},
    "source": [
     "## Fetch a model for prediction\n",
@@ -280,10 +590,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "95eea8aa",
+   "execution_count": 10,
+   "id": "99c967fa",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Downloading data from 'https://northwestern.box.com/shared/static/4g6idrqlpvgxnsktz8pym5386njyvyb6' to file '/root/.cache/pooch/model/tcga_brca_model'.\n",
+      "Unzipping contents of '/root/.cache/pooch/model/tcga_brca_model' to '/root/.cache/pooch/model/tcga_brca_model.unzip'\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Have /root/.cache/pooch/model/tcga_brca_model.unzip/tcga_brca_model.\n",
+      "Downloading data from https://storage.googleapis.com/tensorflow/keras-applications/resnet/resnet50v2_weights_tf_dim_ordering_tf_kernels_notop.h5\n",
+      "94674944/94668760 [==============================] - 1s 0us/step\n",
+      "94683136/94668760 [==============================] - 1s 0us/step\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-03-23 14:34:46.387040: I tensorflow/stream_executor/cuda/cuda_dnn.cc:368] Loaded cuDNN version 8100\n",
+      "2022-03-23 14:34:57.929018: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'gradients/PartitionedCall_6_grad/PartitionedCall' has 3 outputs but the _output_shapes attribute specifies shapes for 33 outputs. Output shapes may be inaccurate.\n",
+      "2022-03-23 14:34:57.929101: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'gradients/PartitionedCall_4_grad/PartitionedCall' has 3 outputs but the _output_shapes attribute specifies shapes for 33 outputs. Output shapes may be inaccurate.\n",
+      "2022-03-23 14:34:57.929216: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'gradients/PartitionedCall_5_grad/PartitionedCall' has 3 outputs but the _output_shapes attribute specifies shapes for 33 outputs. Output shapes may be inaccurate.\n",
+      "2022-03-23 14:34:57.929252: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'gradients/PartitionedCall_2_grad/PartitionedCall' has 1 outputs but the _output_shapes attribute specifies shapes for 6 outputs. Output shapes may be inaccurate.\n",
+      "2022-03-23 14:34:57.929280: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'gradients/PartitionedCall_3_grad/PartitionedCall' has 1 outputs but the _output_shapes attribute specifies shapes for 6 outputs. Output shapes may be inaccurate.\n",
+      "2022-03-23 14:35:01.470280: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'PartitionedCall_2' has 2 outputs but the _output_shapes attribute specifies shapes for 6 outputs. Output shapes may be inaccurate.\n",
+      "2022-03-23 14:35:01.470361: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'PartitionedCall_3' has 2 outputs but the _output_shapes attribute specifies shapes for 6 outputs. Output shapes may be inaccurate.\n",
+      "2022-03-23 14:35:01.470392: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'PartitionedCall_4' has 1 outputs but the _output_shapes attribute specifies shapes for 11 outputs. Output shapes may be inaccurate.\n",
+      "2022-03-23 14:35:01.470437: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'PartitionedCall_5' has 1 outputs but the _output_shapes attribute specifies shapes for 11 outputs. Output shapes may be inaccurate.\n",
+      "2022-03-23 14:35:01.470462: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'PartitionedCall_6' has 1 outputs but the _output_shapes attribute specifies shapes for 11 outputs. Output shapes may be inaccurate.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model built and wrapped.\n"
+     ]
+    }
+   ],
    "source": [
     "# download trained model.\n",
     "model_path = pooch.retrieve(\n",
@@ -321,7 +674,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24dd96aa",
+   "id": "9ddbf37d",
    "metadata": {},
    "source": [
     "## Make predictions"
@@ -329,10 +682,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "31db8094",
+   "execution_count": 11,
+   "id": "16e9124c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting predictions\n",
+      "Made 8019 predictions for 100 tiles in 12.370248794555664 s.\n",
+      "Average of 0.12370248794555665 s per tile.\n"
+     ]
+    }
+   ],
    "source": [
     "import time\n",
     "\n",
@@ -350,12 +713,88 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a18c266b",
+   "cell_type": "markdown",
+   "id": "3cea1d26",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "## Look at internals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "70937a12",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   type(my_element) = <class 'tuple'>\n",
+      "    len(my_element) = 3\n",
+      "      type(my_pair) = <class 'tuple'>\n",
+      "       len(my_pair) = 2\n",
+      "    type(my_target) = <class 'NoneType'>\n",
+      "    type(my_weight) = <class 'NoneType'>\n",
+      "     type(my_image) = <class 'tensorflow.python.framework.ops.EagerTensor'>\n",
+      "     my_image.shape = (512, 512, 3)\n",
+      "type(my_annotation) = <class 'dict'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "my_element = tiles.take(1).get_single_element()\n",
+    "my_pair = my_element[0]\n",
+    "my_target = my_element[1]\n",
+    "my_weight = my_element[2]\n",
+    "my_image = my_pair[0]\n",
+    "my_annotation = my_pair[1]\n",
+    "\n",
+    "print(f\"   type(my_element) = {type(my_element)}\")\n",
+    "print(f\"    len(my_element) = {len(my_element)}\")\n",
+    "print(f\"      type(my_pair) = {type(my_pair)}\")\n",
+    "print(f\"       len(my_pair) = {len(my_pair)}\")\n",
+    "print(f\"    type(my_target) = {type(my_target)}\")\n",
+    "print(f\"    type(my_weight) = {type(my_weight)}\")\n",
+    "print(f\"     type(my_image) = {type(my_image)}\")\n",
+    "print(f\"     my_image.shape = {my_image.shape}\")\n",
+    "print(f\"type(my_annotation) = {type(my_annotation)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ecf793c4",
+   "metadata": {},
+   "source": [
+    "## Display a tile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "b59c56f2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dc549bf2e3b84d288434f2350f2702e0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Viewer(geometries=[], gradient_opacity=0.22, point_sets=[], rendered_image=<itk.itkImagePython.itkImageRGBUC2;…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import itk, itkwidgets\n",
+    "\n",
+    "itkwidgets.view(itk.image_from_array(my_image.numpy(), is_vector=True))"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Improve the `tensorflow_stream.ipynb` jupyter lab.  Specifically,

- Store notebook cells' outputs in the file.
- Separate installation of `histomics_stream` and its dependencies from the installation of other packages that happen to be used in the notebook, including installing `itkwidgets` to Python and `jupyter labextension`.
- Take a single element from `tiles` tensorflow `Dataset` and show its parts, including using `itkwidgets` to show the tile's RGB image.