### PR TITLE
ENH: Explicitly apt install libcudnn8 libcudnn8-dev

### DIFF
--- a/example/tensorflow_stream.ipynb
+++ b/example/tensorflow_stream.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d64ab87a",
+   "id": "b0c50c61",
    "metadata": {},
    "source": [
     "# Demonstration of histomics_stream\n",
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b31e90e",
+   "id": "10f22613",
    "metadata": {},
    "source": [
     "## Installation\n",
@@ -25,26 +25,26 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "55227bac",
+   "id": "d734c74f",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hit:1 http://security.ubuntu.com/ubuntu bionic-security InRelease\n",
-      "Hit:2 https://deb.nodesource.com/node_16.x bionic InRelease                    \u001b[0m\n",
-      "Ign:3 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease\n",
-      "Ign:4 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  InRelease\n",
+      "Hit:1 https://deb.nodesource.com/node_16.x bionic InRelease\n",
+      "Ign:2 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease\n",
+      "Ign:3 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  InRelease\n",
+      "Hit:4 http://security.ubuntu.com/ubuntu bionic-security InRelease       \u001b[0m   \n",
       "Hit:5 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  Release\n",
       "Hit:6 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  Release\n",
       "Hit:7 http://archive.ubuntu.com/ubuntu bionic InRelease\n",
       "Hit:8 http://archive.ubuntu.com/ubuntu bionic-updates InRelease\n",
       "Hit:9 http://archive.ubuntu.com/ubuntu bionic-backports InRelease\n",
-      "Reading package lists... Done\u001b[0m\u001b[33m\u001b[33m\u001b[33m\u001b[33m\u001b[33m\u001b[33m\u001b[33m\n",
+      "Reading package lists... Done\u001b[0m                  \u001b[33m\u001b[33m\u001b[33m\u001b[33m\u001b[33m\u001b[33m\n",
       "Building dependency tree       \n",
       "Reading state information... Done\n",
-      "48 packages can be upgraded. Run 'apt list --upgradable' to see them.\n",
+      "55 packages can be upgraded. Run 'apt list --upgradable' to see them.\n",
       "Reading package lists... Done\n",
       "Building dependency tree       \n",
       "Reading state information... Done\n",
@@ -53,11 +53,11 @@
       "  libtiff-tools\n",
       "The following NEW packages will be installed:\n",
       "  openslide-tools\n",
-      "0 upgraded, 1 newly installed, 0 to remove and 48 not upgraded.\n",
+      "0 upgraded, 1 newly installed, 0 to remove and 55 not upgraded.\n",
       "Need to get 12.7 kB of archives.\n",
       "After this operation, 57.3 kB of additional disk space will be used.\n",
       "Get:1 http://archive.ubuntu.com/ubuntu bionic/universe amd64 openslide-tools amd64 3.4.1+dfsg-2 [12.7 kB]\n",
-      "Fetched 12.7 kB in 0s (185 kB/s)            \u001b[0m\u001b[33m\n",
+      "Fetched 12.7 kB in 0s (66.1 kB/s)           \u001b[0m\u001b[33m\n",
       "debconf: delaying package configuration, since apt-utils is not installed\n",
       "\n",
       "\u001b7\u001b[0;23r\u001b8\u001b[1ASelecting previously unselected package openslide-tools.\n",
@@ -67,170 +67,196 @@
       "\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [ 33%]\u001b[49m\u001b[39m [###################.......................................] \u001b8\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [ 50%]\u001b[49m\u001b[39m [#############################.............................] \u001b8Setting up openslide-tools (3.4.1+dfsg-2) ...\n",
       "\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [ 67%]\u001b[49m\u001b[39m [######################################....................] \u001b8\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [ 83%]\u001b[49m\u001b[39m [################################################..........] \u001b8\n",
       "\u001b7\u001b[0;24r\u001b8\u001b[1A\u001b[JLooking in links: https://girder.github.io/large_image_wheels\n",
-      "Requirement already satisfied: large_image[openslide] in /usr/local/lib/python3.7/dist-packages (1.12.0)\n",
-      "Requirement already satisfied: Pillow in /usr/local/lib/python3.7/dist-packages (from large_image[openslide]) (9.0.1)\n",
+      "Requirement already satisfied: large_image[openslide] in /usr/local/lib/python3.7/dist-packages (1.14.1)\n",
       "Requirement already satisfied: psutil>=4.2.0 in /usr/local/lib/python3.7/dist-packages (from large_image[openslide]) (5.9.0)\n",
-      "Requirement already satisfied: importlib-metadata in /usr/local/lib/python3.7/dist-packages (from large_image[openslide]) (4.11.3)\n",
-      "Requirement already satisfied: numpy>=1.10.4 in /usr/local/lib/python3.7/dist-packages (from large_image[openslide]) (1.21.5)\n",
-      "Requirement already satisfied: cachetools>=3.0.0 in /usr/local/lib/python3.7/dist-packages (from large_image[openslide]) (5.0.0)\n",
       "Requirement already satisfied: palettable in /usr/local/lib/python3.7/dist-packages (from large_image[openslide]) (3.3.0)\n",
-      "Requirement already satisfied: large-image-source-openslide in /usr/local/lib/python3.7/dist-packages (from large_image[openslide]) (1.12.0)\n",
-      "Requirement already satisfied: typing-extensions>=3.6.4 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata->large_image[openslide]) (4.1.1)\n",
-      "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata->large_image[openslide]) (3.7.0)\n",
-      "Requirement already satisfied: tifftools>=1.2.0 in /usr/local/lib/python3.7/dist-packages (from large-image-source-openslide->large_image[openslide]) (1.2.10)\n",
-      "Requirement already satisfied: openslide-python>=1.1.0 in /usr/local/lib/python3.7/dist-packages (from large-image-source-openslide->large_image[openslide]) (1.1.2)\n",
+      "Requirement already satisfied: Pillow in /usr/local/lib/python3.7/dist-packages (from large_image[openslide]) (9.1.0)\n",
+      "Requirement already satisfied: cachetools>=3.0.0 in /usr/local/lib/python3.7/dist-packages (from large_image[openslide]) (5.0.0)\n",
+      "Requirement already satisfied: importlib-metadata in /usr/local/lib/python3.7/dist-packages (from large_image[openslide]) (4.11.3)\n",
+      "Requirement already satisfied: numpy>=1.10.4 in /usr/local/lib/python3.7/dist-packages (from large_image[openslide]) (1.21.6)\n",
+      "Requirement already satisfied: large-image-source-openslide>=1.14.1 in /usr/local/lib/python3.7/dist-packages (from large_image[openslide]) (1.14.1)\n",
+      "Requirement already satisfied: openslide-python>=1.1.0 in /usr/local/lib/python3.7/dist-packages (from large-image-source-openslide>=1.14.1->large_image[openslide]) (1.1.2)\n",
+      "Requirement already satisfied: tifftools>=1.2.0 in /usr/local/lib/python3.7/dist-packages (from large-image-source-openslide>=1.14.1->large_image[openslide]) (1.3.3)\n",
+      "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata->large_image[openslide]) (3.8.0)\n",
+      "Requirement already satisfied: typing-extensions>=3.6.4 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata->large_image[openslide]) (4.2.0)\n",
       "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\u001b[0m\u001b[33m\n",
       "\u001b[0mCollecting histomics_stream\n",
       "  Downloading histomics_stream-2.2.3-py3-none-any.whl (21 kB)\n",
+      "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from histomics_stream) (1.21.6)\n",
       "Requirement already satisfied: openslide-python in /usr/local/lib/python3.7/dist-packages (from histomics_stream) (1.1.2)\n",
-      "Requirement already satisfied: zarr in /usr/local/lib/python3.7/dist-packages (from histomics_stream) (2.11.1)\n",
+      "Requirement already satisfied: zarr in /usr/local/lib/python3.7/dist-packages (from histomics_stream) (2.11.3)\n",
       "Requirement already satisfied: itk in /usr/local/lib/python3.7/dist-packages (from histomics_stream) (5.2.1.post1)\n",
-      "Requirement already satisfied: pillow in /usr/local/lib/python3.7/dist-packages (from histomics_stream) (9.0.1)\n",
-      "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from histomics_stream) (1.21.5)\n",
       "Requirement already satisfied: imagecodecs in /usr/local/lib/python3.7/dist-packages (from histomics_stream) (2021.11.20)\n",
-      "Requirement already satisfied: itk-io==5.2.1.post1 in /usr/local/lib/python3.7/dist-packages (from itk->histomics_stream) (5.2.1.post1)\n",
-      "Requirement already satisfied: itk-segmentation==5.2.1.post1 in /usr/local/lib/python3.7/dist-packages (from itk->histomics_stream) (5.2.1.post1)\n",
+      "Requirement already satisfied: pillow in /usr/local/lib/python3.7/dist-packages (from histomics_stream) (9.1.0)\n",
+      "Requirement already satisfied: itk-registration==5.2.1.post1 in /usr/local/lib/python3.7/dist-packages (from itk->histomics_stream) (5.2.1.post1)\n",
       "Requirement already satisfied: itk-filtering==5.2.1.post1 in /usr/local/lib/python3.7/dist-packages (from itk->histomics_stream) (5.2.1.post1)\n",
       "Requirement already satisfied: itk-numerics==5.2.1.post1 in /usr/local/lib/python3.7/dist-packages (from itk->histomics_stream) (5.2.1.post1)\n",
+      "Requirement already satisfied: itk-segmentation==5.2.1.post1 in /usr/local/lib/python3.7/dist-packages (from itk->histomics_stream) (5.2.1.post1)\n",
       "Requirement already satisfied: itk-core==5.2.1.post1 in /usr/local/lib/python3.7/dist-packages (from itk->histomics_stream) (5.2.1.post1)\n",
-      "Requirement already satisfied: itk-registration==5.2.1.post1 in /usr/local/lib/python3.7/dist-packages (from itk->histomics_stream) (5.2.1.post1)\n",
-      "Requirement already satisfied: fasteners in /usr/local/lib/python3.7/dist-packages (from zarr->histomics_stream) (0.17.3)\n",
-      "Requirement already satisfied: asciitree in /usr/local/lib/python3.7/dist-packages (from zarr->histomics_stream) (0.3.3)\n",
+      "Requirement already satisfied: itk-io==5.2.1.post1 in /usr/local/lib/python3.7/dist-packages (from itk->histomics_stream) (5.2.1.post1)\n",
       "Requirement already satisfied: numcodecs>=0.6.4 in /usr/local/lib/python3.7/dist-packages (from zarr->histomics_stream) (0.9.1)\n",
+      "Requirement already satisfied: asciitree in /usr/local/lib/python3.7/dist-packages (from zarr->histomics_stream) (0.3.3)\n",
+      "Requirement already satisfied: fasteners in /usr/local/lib/python3.7/dist-packages (from zarr->histomics_stream) (0.17.3)\n",
       "Installing collected packages: histomics_stream\n",
       "Successfully installed histomics_stream-2.2.3\n",
       "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\u001b[0m\u001b[33m\n",
-      "\u001b[0mCollecting histomics_detect\n",
+      "Reading package lists... Done\n",
+      "Building dependency tree       \n",
+      "Reading state information... Done\n",
+      "The following NEW packages will be installed:\n",
+      "  libcudnn8-dev\n",
+      "The following packages will be upgraded:\n",
+      "  libcudnn8\n",
+      "1 upgraded, 1 newly installed, 0 to remove and 54 not upgraded.\n",
+      "Need to get 870 MB of archives.\n",
+      "After this operation, 1383 MB of additional disk space will be used.\n",
+      "Get:1 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  libcudnn8 8.4.0.27-1+cuda11.6 [421 MB]\n",
+      "Get:2 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  libcudnn8-dev 8.4.0.27-1+cuda11.6 [449 MB]\n",
+      "Fetched 870 MB in 13s (68.7 MB/s)                                              \u001b[0m\u001b[33m\u001b[33m\u001b[33m\u001b[33m\u001b[33m\u001b[33m\u001b[33m\u001b[33m\u001b[33m\u001b[33m\u001b[33m\u001b[33m\u001b[33m\n",
+      "debconf: delaying package configuration, since apt-utils is not installed\n",
+      "\n",
+      "(Reading database ... 46441 files and directories currently installed.)\n",
+      "Preparing to unpack .../libcudnn8_8.4.0.27-1+cuda11.6_amd64.deb ...\n",
+      "\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [  0%]\u001b[49m\u001b[39m [..........................................................] \u001b8\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [  9%]\u001b[49m\u001b[39m [#####.....................................................] \u001b8Unpacking libcudnn8 (8.4.0.27-1+cuda11.6) over (8.1.0.77-1+cuda11.2) ...\n",
+      "\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [ 18%]\u001b[49m\u001b[39m [##########................................................] \u001b8\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [ 27%]\u001b[49m\u001b[39m [###############...........................................] \u001b8Selecting previously unselected package libcudnn8-dev.\n",
+      "Preparing to unpack .../libcudnn8-dev_8.4.0.27-1+cuda11.6_amd64.deb ...\n",
+      "\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [ 36%]\u001b[49m\u001b[39m [#####################.....................................] \u001b8Unpacking libcudnn8-dev (8.4.0.27-1+cuda11.6) ...\n",
+      "\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [ 45%]\u001b[49m\u001b[39m [##########################................................] \u001b8\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [ 55%]\u001b[49m\u001b[39m [###############################...........................] \u001b8Setting up libcudnn8 (8.4.0.27-1+cuda11.6) ...\n",
+      "\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [ 64%]\u001b[49m\u001b[39m [####################################......................] \u001b8\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [ 73%]\u001b[49m\u001b[39m [##########################################................] \u001b8Setting up libcudnn8-dev (8.4.0.27-1+cuda11.6) ...\n",
+      "\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [ 82%]\u001b[49m\u001b[39m [###############################################...........] \u001b8update-alternatives: using /usr/include/x86_64-linux-gnu/cudnn_v8.h to provide /usr/include/cudnn.h (libcudnn) in auto mode\n",
+      "\u001b7\u001b[24;0f\u001b[42m\u001b[30mProgress: [ 91%]\u001b[49m\u001b[39m [####################################################......] \u001b8\n",
+      "\u001b7\u001b[0;24r\u001b8\u001b[1A\u001b[JCollecting histomics_detect\n",
       "  Downloading histomics_detect-0.0.1-py3-none-any.whl (68 kB)\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m68.4/68.4 KB\u001b[0m \u001b[31m13.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m68.4/68.4 KB\u001b[0m \u001b[31m12.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25hCollecting pooch\n",
       "  Downloading pooch-1.6.0-py3-none-any.whl (56 kB)\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.3/56.3 KB\u001b[0m \u001b[31m11.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.3/56.3 KB\u001b[0m \u001b[31m10.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25hRequirement already satisfied: itkwidgets in /usr/local/lib/python3.7/dist-packages (0.32.1)\n",
+      "Requirement already satisfied: Pillow in /usr/local/lib/python3.7/dist-packages (from histomics_detect) (9.1.0)\n",
+      "Requirement already satisfied: tensorflow-gpu>=2.4 in /usr/local/lib/python3.7/dist-packages (from histomics_detect) (2.8.0)\n",
+      "Requirement already satisfied: scipy in /usr/local/lib/python3.7/dist-packages (from histomics_detect) (1.7.3)\n",
       "Collecting pandas\n",
       "  Downloading pandas-1.3.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (11.3 MB)\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m11.3/11.3 MB\u001b[0m \u001b[31m78.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
-      "\u001b[?25hRequirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from histomics_detect) (1.21.5)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m11.3/11.3 MB\u001b[0m \u001b[31m61.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m0:01\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: matplotlib in /usr/local/lib/python3.7/dist-packages (from histomics_detect) (3.5.1)\n",
       "Collecting pyyaml\n",
       "  Downloading PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (596 kB)\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m596.3/596.3 KB\u001b[0m \u001b[31m41.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25hRequirement already satisfied: scipy in /usr/local/lib/python3.7/dist-packages (from histomics_detect) (1.7.3)\n",
-      "Requirement already satisfied: tensorflow-gpu>=2.4 in /usr/local/lib/python3.7/dist-packages (from histomics_detect) (2.8.0)\n",
-      "Requirement already satisfied: matplotlib in /usr/local/lib/python3.7/dist-packages (from histomics_detect) (3.5.1)\n",
-      "Requirement already satisfied: Pillow in /usr/local/lib/python3.7/dist-packages (from histomics_detect) (9.0.1)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m596.3/596.3 KB\u001b[0m \u001b[31m42.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from histomics_detect) (1.21.6)\n",
+      "Requirement already satisfied: packaging>=20.0 in /usr/local/lib/python3.7/dist-packages (from pooch) (21.3)\n",
       "Collecting appdirs>=1.3.0\n",
       "  Downloading appdirs-1.4.4-py2.py3-none-any.whl (9.6 kB)\n",
-      "Requirement already satisfied: packaging>=20.0 in /usr/local/lib/python3.7/dist-packages (from pooch) (21.3)\n",
       "Requirement already satisfied: requests>=2.19.0 in /usr/local/lib/python3.7/dist-packages (from pooch) (2.27.1)\n",
+      "Requirement already satisfied: itk-filtering>=5.2.0.post2 in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (5.2.1.post1)\n",
       "Requirement already satisfied: zstandard in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (0.17.0)\n",
       "Requirement already satisfied: ipydatawidgets>=4.0.1 in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (4.2.0)\n",
-      "Requirement already satisfied: ipywidgets>=7.5.1 in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (7.7.0)\n",
+      "Requirement already satisfied: ipympl>=0.4.1 in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (0.9.1)\n",
       "Requirement already satisfied: six in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (1.16.0)\n",
-      "Requirement already satisfied: ipympl>=0.4.1 in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (0.8.8)\n",
+      "Requirement already satisfied: ipywidgets>=7.5.1 in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (7.7.0)\n",
       "Requirement already satisfied: colorcet in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (3.0.0)\n",
-      "Requirement already satisfied: itk-meshtopolydata>=0.7.1 in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (0.7.1)\n",
       "Requirement already satisfied: itk-core>=5.2.0.post2 in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (5.2.1.post1)\n",
-      "Requirement already satisfied: itk-filtering>=5.2.0.post2 in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (5.2.1.post1)\n",
+      "Requirement already satisfied: itk-meshtopolydata>=0.7.1 in /usr/local/lib/python3.7/dist-packages (from itkwidgets) (0.8.1)\n",
       "Requirement already satisfied: traittypes>=0.2.0 in /usr/local/lib/python3.7/dist-packages (from ipydatawidgets>=4.0.1->itkwidgets) (0.2.1)\n",
+      "Requirement already satisfied: traitlets<6 in /usr/local/lib/python3.7/dist-packages (from ipympl>=0.4.1->itkwidgets) (5.1.1)\n",
       "Requirement already satisfied: ipython<9 in /usr/local/lib/python3.7/dist-packages (from ipympl>=0.4.1->itkwidgets) (7.32.0)\n",
       "Requirement already satisfied: ipython-genutils in /usr/local/lib/python3.7/dist-packages (from ipympl>=0.4.1->itkwidgets) (0.2.0)\n",
-      "Requirement already satisfied: traitlets<6 in /usr/local/lib/python3.7/dist-packages (from ipympl>=0.4.1->itkwidgets) (5.1.1)\n",
-      "Requirement already satisfied: nbformat>=4.2.0 in /usr/local/lib/python3.7/dist-packages (from ipywidgets>=7.5.1->itkwidgets) (5.2.0)\n",
+      "Requirement already satisfied: ipykernel>=4.5.1 in /usr/local/lib/python3.7/dist-packages (from ipywidgets>=7.5.1->itkwidgets) (6.13.0)\n",
       "Requirement already satisfied: jupyterlab-widgets>=1.0.0 in /usr/local/lib/python3.7/dist-packages (from ipywidgets>=7.5.1->itkwidgets) (1.1.0)\n",
-      "Requirement already satisfied: ipykernel>=4.5.1 in /usr/local/lib/python3.7/dist-packages (from ipywidgets>=7.5.1->itkwidgets) (6.9.2)\n",
+      "Requirement already satisfied: nbformat>=4.2.0 in /usr/local/lib/python3.7/dist-packages (from ipywidgets>=7.5.1->itkwidgets) (5.3.0)\n",
       "Requirement already satisfied: widgetsnbextension~=3.6.0 in /usr/local/lib/python3.7/dist-packages (from ipywidgets>=7.5.1->itkwidgets) (3.6.0)\n",
       "Requirement already satisfied: itk-numerics==5.2.1.post1 in /usr/local/lib/python3.7/dist-packages (from itk-filtering>=5.2.0.post2->itkwidgets) (5.2.1.post1)\n",
-      "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib->histomics_detect) (1.4.0)\n",
-      "Requirement already satisfied: python-dateutil>=2.7 in /usr/local/lib/python3.7/dist-packages (from matplotlib->histomics_detect) (2.8.2)\n",
-      "Requirement already satisfied: fonttools>=4.22.0 in /usr/local/lib/python3.7/dist-packages (from matplotlib->histomics_detect) (4.31.2)\n",
-      "Requirement already satisfied: pyparsing>=2.2.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib->histomics_detect) (3.0.7)\n",
+      "Requirement already satisfied: fonttools>=4.22.0 in /usr/local/lib/python3.7/dist-packages (from matplotlib->histomics_detect) (4.33.3)\n",
       "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.7/dist-packages (from matplotlib->histomics_detect) (0.11.0)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.7/dist-packages (from requests>=2.19.0->pooch) (2021.10.8)\n",
+      "Requirement already satisfied: python-dateutil>=2.7 in /usr/local/lib/python3.7/dist-packages (from matplotlib->histomics_detect) (2.8.2)\n",
+      "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib->histomics_detect) (1.4.2)\n",
+      "Requirement already satisfied: pyparsing>=2.2.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib->histomics_detect) (3.0.8)\n",
       "Requirement already satisfied: charset-normalizer~=2.0.0 in /usr/local/lib/python3.7/dist-packages (from requests>=2.19.0->pooch) (2.0.12)\n",
-      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /usr/local/lib/python3.7/dist-packages (from requests>=2.19.0->pooch) (1.26.9)\n",
       "Requirement already satisfied: idna<4,>=2.5 in /usr/lib/python3/dist-packages (from requests>=2.19.0->pooch) (2.6)\n",
-      "Requirement already satisfied: grpcio<2.0,>=1.24.3 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (1.44.0)\n",
-      "Requirement already satisfied: absl-py>=0.4.0 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (1.0.0)\n",
+      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /usr/local/lib/python3.7/dist-packages (from requests>=2.19.0->pooch) (1.26.9)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.7/dist-packages (from requests>=2.19.0->pooch) (2021.10.8)\n",
       "Requirement already satisfied: tf-estimator-nightly==2.8.0.dev2021122109 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (2.8.0.dev2021122109)\n",
-      "Requirement already satisfied: astunparse>=1.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (1.6.3)\n",
-      "Requirement already satisfied: libclang>=9.0.1 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (13.0.0)\n",
-      "Requirement already satisfied: wrapt>=1.11.0 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (1.14.0)\n",
-      "Requirement already satisfied: keras-preprocessing>=1.1.1 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (1.1.2)\n",
-      "Requirement already satisfied: termcolor>=1.1.0 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (1.1.0)\n",
-      "Requirement already satisfied: protobuf>=3.9.2 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (3.19.4)\n",
-      "Requirement already satisfied: google-pasta>=0.1.1 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (0.2.0)\n",
-      "Requirement already satisfied: gast>=0.2.1 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (0.5.3)\n",
-      "Requirement already satisfied: flatbuffers>=1.12 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (2.0)\n",
-      "Requirement already satisfied: setuptools in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (60.10.0)\n",
-      "Requirement already satisfied: opt-einsum>=2.3.2 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (3.3.0)\n",
-      "Requirement already satisfied: tensorboard<2.9,>=2.8 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (2.8.0)\n",
-      "Requirement already satisfied: tensorflow-io-gcs-filesystem>=0.23.1 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (0.24.0)\n",
-      "Requirement already satisfied: keras<2.9,>=2.8.0rc0 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (2.8.0)\n",
       "Requirement already satisfied: h5py>=2.9.0 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (3.6.0)\n",
-      "Requirement already satisfied: typing-extensions>=3.6.6 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (4.1.1)\n",
-      "Requirement already satisfied: param>=1.7.0 in /usr/local/lib/python3.7/dist-packages (from colorcet->itkwidgets) (1.12.0)\n",
+      "Requirement already satisfied: google-pasta>=0.1.1 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (0.2.0)\n",
+      "Requirement already satisfied: absl-py>=0.4.0 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (1.0.0)\n",
+      "Requirement already satisfied: grpcio<2.0,>=1.24.3 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (1.44.0)\n",
+      "Requirement already satisfied: astunparse>=1.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (1.6.3)\n",
+      "Requirement already satisfied: termcolor>=1.1.0 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (1.1.0)\n",
+      "Requirement already satisfied: gast>=0.2.1 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (0.5.3)\n",
+      "Requirement already satisfied: wrapt>=1.11.0 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (1.14.0)\n",
+      "Requirement already satisfied: tensorboard<2.9,>=2.8 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (2.8.0)\n",
+      "Requirement already satisfied: opt-einsum>=2.3.2 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (3.3.0)\n",
+      "Requirement already satisfied: tensorflow-io-gcs-filesystem>=0.23.1 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (0.25.0)\n",
+      "Requirement already satisfied: protobuf>=3.9.2 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (3.20.1)\n",
+      "Requirement already satisfied: setuptools in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (62.1.0)\n",
+      "Requirement already satisfied: flatbuffers>=1.12 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (2.0)\n",
+      "Requirement already satisfied: keras-preprocessing>=1.1.1 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (1.1.2)\n",
+      "Requirement already satisfied: libclang>=9.0.1 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (14.0.1)\n",
+      "Requirement already satisfied: typing-extensions>=3.6.6 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (4.2.0)\n",
+      "Requirement already satisfied: keras<2.9,>=2.8.0rc0 in /usr/local/lib/python3.7/dist-packages (from tensorflow-gpu>=2.4->histomics_detect) (2.8.0)\n",
+      "Requirement already satisfied: param>=1.7.0 in /usr/local/lib/python3.7/dist-packages (from colorcet->itkwidgets) (1.12.1)\n",
       "Requirement already satisfied: pyct>=0.4.4 in /usr/local/lib/python3.7/dist-packages (from colorcet->itkwidgets) (0.4.8)\n",
       "Collecting pytz>=2017.3\n",
       "  Downloading pytz-2022.1-py2.py3-none-any.whl (503 kB)\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m503.5/503.5 KB\u001b[0m \u001b[31m44.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m503.5/503.5 KB\u001b[0m \u001b[31m45.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25hRequirement already satisfied: wheel<1.0,>=0.23.0 in /usr/local/lib/python3.7/dist-packages (from astunparse>=1.6.0->tensorflow-gpu>=2.4->histomics_detect) (0.37.1)\n",
       "Requirement already satisfied: cached-property in /usr/local/lib/python3.7/dist-packages (from h5py>=2.9.0->tensorflow-gpu>=2.4->histomics_detect) (1.5.2)\n",
+      "Requirement already satisfied: tornado>=6.1 in /usr/local/lib/python3.7/dist-packages (from ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (6.1)\n",
+      "Requirement already satisfied: matplotlib-inline>=0.1 in /usr/local/lib/python3.7/dist-packages (from ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (0.1.3)\n",
       "Requirement already satisfied: psutil in /usr/local/lib/python3.7/dist-packages (from ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (5.9.0)\n",
-      "Requirement already satisfied: jupyter-client<8.0 in /usr/local/lib/python3.7/dist-packages (from ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (7.1.2)\n",
-      "Requirement already satisfied: matplotlib-inline<0.2.0,>=0.1.0 in /usr/local/lib/python3.7/dist-packages (from ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (0.1.3)\n",
-      "Requirement already satisfied: nest-asyncio in /usr/local/lib/python3.7/dist-packages (from ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (1.5.4)\n",
-      "Requirement already satisfied: tornado<7.0,>=4.2 in /usr/local/lib/python3.7/dist-packages (from ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (6.1)\n",
-      "Requirement already satisfied: debugpy<2.0,>=1.0.0 in /usr/local/lib/python3.7/dist-packages (from ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (1.5.1)\n",
-      "Requirement already satisfied: pickleshare in /usr/local/lib/python3.7/dist-packages (from ipython<9->ipympl>=0.4.1->itkwidgets) (0.7.5)\n",
-      "Requirement already satisfied: decorator in /usr/local/lib/python3.7/dist-packages (from ipython<9->ipympl>=0.4.1->itkwidgets) (5.1.1)\n",
-      "Requirement already satisfied: pygments in /usr/local/lib/python3.7/dist-packages (from ipython<9->ipympl>=0.4.1->itkwidgets) (2.11.2)\n",
-      "Requirement already satisfied: backcall in /usr/local/lib/python3.7/dist-packages (from ipython<9->ipympl>=0.4.1->itkwidgets) (0.2.0)\n",
+      "Requirement already satisfied: nest-asyncio in /usr/local/lib/python3.7/dist-packages (from ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (1.5.5)\n",
+      "Requirement already satisfied: jupyter-client>=6.1.12 in /usr/local/lib/python3.7/dist-packages (from ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (7.3.0)\n",
+      "Requirement already satisfied: debugpy>=1.0 in /usr/local/lib/python3.7/dist-packages (from ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (1.6.0)\n",
+      "Requirement already satisfied: pygments in /usr/local/lib/python3.7/dist-packages (from ipython<9->ipympl>=0.4.1->itkwidgets) (2.12.0)\n",
       "Requirement already satisfied: pexpect>4.3 in /usr/local/lib/python3.7/dist-packages (from ipython<9->ipympl>=0.4.1->itkwidgets) (4.8.0)\n",
+      "Requirement already satisfied: pickleshare in /usr/local/lib/python3.7/dist-packages (from ipython<9->ipympl>=0.4.1->itkwidgets) (0.7.5)\n",
+      "Requirement already satisfied: backcall in /usr/local/lib/python3.7/dist-packages (from ipython<9->ipympl>=0.4.1->itkwidgets) (0.2.0)\n",
       "Requirement already satisfied: jedi>=0.16 in /usr/local/lib/python3.7/dist-packages (from ipython<9->ipympl>=0.4.1->itkwidgets) (0.18.1)\n",
-      "Requirement already satisfied: prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0 in /usr/local/lib/python3.7/dist-packages (from ipython<9->ipympl>=0.4.1->itkwidgets) (3.0.28)\n",
-      "Requirement already satisfied: jupyter-core in /usr/local/lib/python3.7/dist-packages (from nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (4.9.2)\n",
-      "Requirement already satisfied: jsonschema!=2.5.0,>=2.4 in /usr/local/lib/python3.7/dist-packages (from nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (4.4.0)\n",
-      "Requirement already satisfied: markdown>=2.6.8 in /usr/local/lib/python3.7/dist-packages (from tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (3.3.6)\n",
-      "Requirement already satisfied: google-auth-oauthlib<0.5,>=0.4.1 in /usr/local/lib/python3.7/dist-packages (from tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (0.4.6)\n",
-      "Requirement already satisfied: google-auth<3,>=1.6.3 in /usr/local/lib/python3.7/dist-packages (from tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (2.6.2)\n",
-      "Requirement already satisfied: werkzeug>=0.11.15 in /usr/local/lib/python3.7/dist-packages (from tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (2.0.3)\n",
-      "Requirement already satisfied: tensorboard-plugin-wit>=1.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (1.8.1)\n",
+      "Requirement already satisfied: decorator in /usr/local/lib/python3.7/dist-packages (from ipython<9->ipympl>=0.4.1->itkwidgets) (5.1.1)\n",
+      "Requirement already satisfied: prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0 in /usr/local/lib/python3.7/dist-packages (from ipython<9->ipympl>=0.4.1->itkwidgets) (3.0.29)\n",
+      "Requirement already satisfied: fastjsonschema in /usr/local/lib/python3.7/dist-packages (from nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (2.15.3)\n",
+      "Requirement already satisfied: jsonschema>=2.6 in /usr/local/lib/python3.7/dist-packages (from nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (4.4.0)\n",
+      "Requirement already satisfied: jupyter-core in /usr/local/lib/python3.7/dist-packages (from nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (4.10.0)\n",
+      "Requirement already satisfied: google-auth<3,>=1.6.3 in /usr/local/lib/python3.7/dist-packages (from tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (2.6.6)\n",
+      "Requirement already satisfied: werkzeug>=0.11.15 in /usr/local/lib/python3.7/dist-packages (from tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (2.1.1)\n",
       "Requirement already satisfied: tensorboard-data-server<0.7.0,>=0.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (0.6.1)\n",
-      "Requirement already satisfied: notebook>=4.4.1 in /usr/local/lib/python3.7/dist-packages (from widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (6.4.10)\n",
-      "Requirement already satisfied: cachetools<6.0,>=2.0.0 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (5.0.0)\n",
-      "Requirement already satisfied: rsa<5,>=3.1.4 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (4.8)\n",
+      "Requirement already satisfied: tensorboard-plugin-wit>=1.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (1.8.1)\n",
+      "Requirement already satisfied: google-auth-oauthlib<0.5,>=0.4.1 in /usr/local/lib/python3.7/dist-packages (from tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (0.4.6)\n",
+      "Requirement already satisfied: markdown>=2.6.8 in /usr/local/lib/python3.7/dist-packages (from tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (3.3.6)\n",
+      "Requirement already satisfied: notebook>=4.4.1 in /usr/local/lib/python3.7/dist-packages (from widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (6.4.11)\n",
       "Requirement already satisfied: pyasn1-modules>=0.2.1 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (0.2.8)\n",
+      "Requirement already satisfied: rsa<5,>=3.1.4 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (4.8)\n",
+      "Requirement already satisfied: cachetools<6.0,>=2.0.0 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (5.0.0)\n",
       "Requirement already satisfied: requests-oauthlib>=0.7.0 in /usr/local/lib/python3.7/dist-packages (from google-auth-oauthlib<0.5,>=0.4.1->tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (1.3.1)\n",
       "Requirement already satisfied: parso<0.9.0,>=0.8.0 in /usr/local/lib/python3.7/dist-packages (from jedi>=0.16->ipython<9->ipympl>=0.4.1->itkwidgets) (0.8.3)\n",
-      "Requirement already satisfied: importlib-resources>=1.4.0 in /usr/local/lib/python3.7/dist-packages (from jsonschema!=2.5.0,>=2.4->nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (5.4.0)\n",
-      "Requirement already satisfied: pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 in /usr/local/lib/python3.7/dist-packages (from jsonschema!=2.5.0,>=2.4->nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (0.18.1)\n",
-      "Requirement already satisfied: attrs>=17.4.0 in /usr/local/lib/python3.7/dist-packages (from jsonschema!=2.5.0,>=2.4->nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (21.4.0)\n",
-      "Requirement already satisfied: importlib-metadata in /usr/local/lib/python3.7/dist-packages (from jsonschema!=2.5.0,>=2.4->nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (4.11.3)\n",
-      "Requirement already satisfied: entrypoints in /usr/local/lib/python3.7/dist-packages (from jupyter-client<8.0->ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (0.4)\n",
-      "Requirement already satisfied: pyzmq>=13 in /usr/local/lib/python3.7/dist-packages (from jupyter-client<8.0->ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (22.3.0)\n",
-      "Requirement already satisfied: argon2-cffi in /usr/local/lib/python3.7/dist-packages (from notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (21.3.0)\n",
-      "Requirement already satisfied: jinja2 in /usr/local/lib/python3.7/dist-packages (from notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (3.0.3)\n",
-      "Requirement already satisfied: nbconvert>=5 in /usr/local/lib/python3.7/dist-packages (from notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (6.4.4)\n",
+      "Requirement already satisfied: importlib-metadata in /usr/local/lib/python3.7/dist-packages (from jsonschema>=2.6->nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (4.11.3)\n",
+      "Requirement already satisfied: pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 in /usr/local/lib/python3.7/dist-packages (from jsonschema>=2.6->nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (0.18.1)\n",
+      "Requirement already satisfied: importlib-resources>=1.4.0 in /usr/local/lib/python3.7/dist-packages (from jsonschema>=2.6->nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (5.7.1)\n",
+      "Requirement already satisfied: attrs>=17.4.0 in /usr/local/lib/python3.7/dist-packages (from jsonschema>=2.6->nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (21.4.0)\n",
+      "Requirement already satisfied: entrypoints in /usr/local/lib/python3.7/dist-packages (from jupyter-client>=6.1.12->ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (0.4)\n",
+      "Requirement already satisfied: pyzmq>=22.3 in /usr/local/lib/python3.7/dist-packages (from jupyter-client>=6.1.12->ipykernel>=4.5.1->ipywidgets>=7.5.1->itkwidgets) (22.3.0)\n",
+      "Requirement already satisfied: nbconvert>=5 in /usr/local/lib/python3.7/dist-packages (from notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (6.5.0)\n",
       "Requirement already satisfied: Send2Trash>=1.8.0 in /usr/local/lib/python3.7/dist-packages (from notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (1.8.0)\n",
+      "Requirement already satisfied: jinja2 in /usr/local/lib/python3.7/dist-packages (from notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (3.1.1)\n",
       "Requirement already satisfied: terminado>=0.8.3 in /usr/local/lib/python3.7/dist-packages (from notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (0.13.3)\n",
-      "Requirement already satisfied: prometheus-client in /usr/local/lib/python3.7/dist-packages (from notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (0.13.1)\n",
+      "Requirement already satisfied: argon2-cffi in /usr/local/lib/python3.7/dist-packages (from notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (21.3.0)\n",
+      "Requirement already satisfied: prometheus-client in /usr/local/lib/python3.7/dist-packages (from notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (0.14.1)\n",
       "Requirement already satisfied: ptyprocess>=0.5 in /usr/local/lib/python3.7/dist-packages (from pexpect>4.3->ipython<9->ipympl>=0.4.1->itkwidgets) (0.7.0)\n",
       "Requirement already satisfied: wcwidth in /usr/local/lib/python3.7/dist-packages (from prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0->ipython<9->ipympl>=0.4.1->itkwidgets) (0.2.5)\n",
-      "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata->jsonschema!=2.5.0,>=2.4->nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (3.7.0)\n",
-      "Requirement already satisfied: testpath in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (0.6.0)\n",
-      "Requirement already satisfied: bleach in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (4.1.0)\n",
-      "Requirement already satisfied: nbclient<0.6.0,>=0.5.0 in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (0.5.13)\n",
+      "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata->jsonschema>=2.6->nbformat>=4.2.0->ipywidgets>=7.5.1->itkwidgets) (3.8.0)\n",
       "Requirement already satisfied: defusedxml in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (0.7.1)\n",
-      "Requirement already satisfied: jupyterlab-pygments in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (0.1.2)\n",
-      "Requirement already satisfied: beautifulsoup4 in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (4.10.0)\n",
-      "Requirement already satisfied: mistune<2,>=0.8.1 in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (0.8.4)\n",
+      "Requirement already satisfied: nbclient>=0.5.0 in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (0.6.0)\n",
+      "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (2.1.1)\n",
       "Requirement already satisfied: pandocfilters>=1.4.1 in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (1.5.0)\n",
-      "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.7/dist-packages (from jinja2->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (2.1.1)\n",
+      "Requirement already satisfied: tinycss2 in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (1.1.1)\n",
+      "Requirement already satisfied: mistune<2,>=0.8.1 in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (0.8.4)\n",
+      "Requirement already satisfied: beautifulsoup4 in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (4.11.1)\n",
+      "Requirement already satisfied: jupyterlab-pygments in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (0.2.2)\n",
+      "Requirement already satisfied: bleach in /usr/local/lib/python3.7/dist-packages (from nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (5.0.0)\n",
       "Requirement already satisfied: pyasn1<0.5.0,>=0.4.6 in /usr/local/lib/python3.7/dist-packages (from pyasn1-modules>=0.2.1->google-auth<3,>=1.6.3->tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (0.4.8)\n",
       "Requirement already satisfied: oauthlib>=3.0.0 in /usr/local/lib/python3.7/dist-packages (from requests-oauthlib>=0.7.0->google-auth-oauthlib<0.5,>=0.4.1->tensorboard<2.9,>=2.8->tensorflow-gpu>=2.4->histomics_detect) (3.2.0)\n",
       "Requirement already satisfied: argon2-cffi-bindings in /usr/local/lib/python3.7/dist-packages (from argon2-cffi->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (21.2.0)\n",
       "Requirement already satisfied: cffi>=1.0.1 in /usr/local/lib/python3.7/dist-packages (from argon2-cffi-bindings->argon2-cffi->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (1.15.0)\n",
-      "Requirement already satisfied: soupsieve>1.2 in /usr/local/lib/python3.7/dist-packages (from beautifulsoup4->nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (2.3.1)\n",
+      "Requirement already satisfied: soupsieve>1.2 in /usr/local/lib/python3.7/dist-packages (from beautifulsoup4->nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (2.3.2.post1)\n",
       "Requirement already satisfied: webencodings in /usr/local/lib/python3.7/dist-packages (from bleach->nbconvert>=5->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (0.5.1)\n",
       "Requirement already satisfied: pycparser in /usr/local/lib/python3.7/dist-packages (from cffi>=1.0.1->argon2-cffi-bindings->argon2-cffi->notebook>=4.4.1->widgetsnbextension~=3.6.0->ipywidgets>=7.5.1->itkwidgets) (2.21)\n",
       "Installing collected packages: pytz, appdirs, pyyaml, pooch, pandas, histomics_detect\n",
@@ -251,6 +277,7 @@
     "\n",
     "# Get other packages used in this notebook\n",
     "# N.B. itkwidgets works with jupyter<=3.0.0\n",
+    "!apt install libcudnn8 libcudnn8-dev\n",
     "!pip install histomics_detect pooch itkwidgets\n",
     "!jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-matplotlib jupyterlab-datawidgets itkwidgets\n",
     "\n",
@@ -261,7 +288,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e07e30f1",
+   "id": "1b4b1fd0",
    "metadata": {},
    "source": [
     "## Fetching and creating the test data\n",
@@ -271,7 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "d4c8ef2f",
+   "id": "8b9784b2",
    "metadata": {},
    "outputs": [
     {
@@ -316,7 +343,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41481d71",
+   "id": "cb4179b8",
    "metadata": {},
    "source": [
     "## Creating a study for use with histomics_stream\n",
@@ -329,7 +356,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "d249abdc",
+   "id": "00246460",
    "metadata": {},
    "outputs": [
     {
@@ -378,7 +405,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c63d978",
+   "id": "dd18bd4e",
    "metadata": {},
    "source": [
     "## Tile selection\n",
@@ -389,7 +416,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "67c9acbc",
+   "id": "4b4e5990",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -399,14 +426,14 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "fed52e54",
+   "id": "56e2d816",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "my_study_tiles_by_grid = {'version': 'version-1', 'number_pixel_rows_for_tile': 256, 'number_pixel_columns_for_tile': 256, 'slides': {'Slide_0': {'filename': '/root/.cache/pooch/wsi/TCGA-AN-A0G0-01Z-00-DX1.svs', 'slide_name': 'TCGA-AN-A0G0-01Z-00-DX1', 'slide_group': 'Group 3', 'number_pixel_rows_for_chunk': 2048, 'number_pixel_columns_for_chunk': 2048, 'target_magnification': 20.0, 'scan_magnification': 40.0, 'read_magnification': 40.0, 'returned_magnification': 40.0, 'level': 8, 'number_pixel_rows_for_slide': 20572, 'number_pixel_columns_for_slide': 27607, 'number_tile_rows_for_slide': 91, 'number_tile_columns_for_slide': 123, 'tiles': {'tile_4523': {'tile_top': 8064, 'tile_left': 21280}, 'tile_6445': {'tile_top': 11648, 'tile_left': 10976}, 'tile_7515': {'tile_top': 13664, 'tile_left': 2688}, 'tile_9840': {'tile_top': 17920, 'tile_left': 0}, 'tile_10972': {'tile_top': 19936, 'tile_left': 5600}}}}}\n"
+      "my_study_tiles_by_grid = {'version': 'version-1', 'number_pixel_rows_for_tile': 256, 'number_pixel_columns_for_tile': 256, 'slides': {'Slide_0': {'filename': '/root/.cache/pooch/wsi/TCGA-AN-A0G0-01Z-00-DX1.svs', 'slide_name': 'TCGA-AN-A0G0-01Z-00-DX1', 'slide_group': 'Group 3', 'number_pixel_rows_for_chunk': 2048, 'number_pixel_columns_for_chunk': 2048, 'target_magnification': 20.0, 'scan_magnification': 40.0, 'read_magnification': 40.0, 'returned_magnification': 40.0, 'level': 8, 'number_pixel_rows_for_slide': 20572, 'number_pixel_columns_for_slide': 27607, 'number_tile_rows_for_slide': 91, 'number_tile_columns_for_slide': 123, 'tiles': {'tile_2912': {'tile_top': 5152, 'tile_left': 18592}, 'tile_6396': {'tile_top': 11648, 'tile_left': 0}, 'tile_6517': {'tile_top': 11648, 'tile_left': 27104}, 'tile_10782': {'tile_top': 19488, 'tile_left': 18144}, 'tile_10876': {'tile_top': 19712, 'tile_left': 11648}}}}}\n"
      ]
     }
    ],
@@ -429,14 +456,14 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "4a469c81",
+   "id": "018d44a8",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "my_study_tiles_by_grid_and_mask = {'version': 'version-1', 'number_pixel_rows_for_tile': 256, 'number_pixel_columns_for_tile': 256, 'slides': {'Slide_0': {'filename': '/root/.cache/pooch/wsi/TCGA-AN-A0G0-01Z-00-DX1.svs', 'slide_name': 'TCGA-AN-A0G0-01Z-00-DX1', 'slide_group': 'Group 3', 'number_pixel_rows_for_chunk': 2048, 'number_pixel_columns_for_chunk': 2048, 'target_magnification': 20.0, 'scan_magnification': 40.0, 'read_magnification': 40.0, 'returned_magnification': 40.0, 'level': 8, 'number_pixel_rows_for_slide': 20572, 'number_pixel_columns_for_slide': 27607, 'number_tile_rows_for_slide': 80, 'number_tile_columns_for_slide': 107, 'number_pixel_rows_for_mask': 642, 'number_pixel_columns_for_mask': 862, 'tiles': {'tile_3050': {'tile_top': 7168, 'tile_left': 13824}, 'tile_3412': {'tile_top': 7936, 'tile_left': 24320}, 'tile_3468': {'tile_top': 8192, 'tile_left': 11264}, 'tile_3698': {'tile_top': 8704, 'tile_left': 15360}, 'tile_4307': {'tile_top': 10240, 'tile_left': 6912}, 'tile_4460': {'tile_top': 10496, 'tile_left': 18688}, 'tile_5638': {'tile_top': 13312, 'tile_left': 18944}, 'tile_6916': {'tile_top': 16384, 'tile_left': 17408}, 'tile_7147': {'tile_top': 16896, 'tile_left': 21760}, 'tile_7575': {'tile_top': 17920, 'tile_left': 21760}}}}}\n"
+      "my_study_tiles_by_grid_and_mask = {'version': 'version-1', 'number_pixel_rows_for_tile': 256, 'number_pixel_columns_for_tile': 256, 'slides': {'Slide_0': {'filename': '/root/.cache/pooch/wsi/TCGA-AN-A0G0-01Z-00-DX1.svs', 'slide_name': 'TCGA-AN-A0G0-01Z-00-DX1', 'slide_group': 'Group 3', 'number_pixel_rows_for_chunk': 2048, 'number_pixel_columns_for_chunk': 2048, 'target_magnification': 20.0, 'scan_magnification': 40.0, 'read_magnification': 40.0, 'returned_magnification': 40.0, 'level': 8, 'number_pixel_rows_for_slide': 20572, 'number_pixel_columns_for_slide': 27607, 'number_tile_rows_for_slide': 80, 'number_tile_columns_for_slide': 107, 'number_pixel_rows_for_mask': 642, 'number_pixel_columns_for_mask': 862, 'tiles': {'tile_298': {'tile_top': 512, 'tile_left': 21504}, 'tile_2758': {'tile_top': 6400, 'tile_left': 21248}, 'tile_3693': {'tile_top': 8704, 'tile_left': 14080}, 'tile_4256': {'tile_top': 9984, 'tile_left': 21248}, 'tile_4431': {'tile_top': 10496, 'tile_left': 11264}, 'tile_4672': {'tile_top': 11008, 'tile_left': 18176}, 'tile_4865': {'tile_top': 11520, 'tile_left': 12800}, 'tile_5220': {'tile_top': 12288, 'tile_left': 21504}, 'tile_6353': {'tile_top': 15104, 'tile_left': 10240}, 'tile_6930': {'tile_top': 16384, 'tile_left': 20992}}}}}\n"
      ]
     }
    ],
@@ -460,14 +487,14 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "ee91ba28",
+   "id": "91970864",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "my_study_tiles_by_list = {'version': 'version-1', 'number_pixel_rows_for_tile': 256, 'number_pixel_columns_for_tile': 256, 'slides': {'Slide_0': {'filename': '/root/.cache/pooch/wsi/TCGA-AN-A0G0-01Z-00-DX1.svs', 'slide_name': 'TCGA-AN-A0G0-01Z-00-DX1', 'slide_group': 'Group 3', 'number_pixel_rows_for_chunk': 2048, 'number_pixel_columns_for_chunk': 2048, 'target_magnification': 20.0, 'scan_magnification': 40.0, 'read_magnification': 40.0, 'returned_magnification': 40.0, 'level': 8, 'number_pixel_rows_for_slide': 20572, 'number_pixel_columns_for_slide': 27607, 'tiles': {'tile_4523': {'tile_top': 8064, 'tile_left': 21280}, 'tile_6445': {'tile_top': 11648, 'tile_left': 10976}, 'tile_7515': {'tile_top': 13664, 'tile_left': 2688}, 'tile_9840': {'tile_top': 17920, 'tile_left': 0}, 'tile_10972': {'tile_top': 19936, 'tile_left': 5600}}}}}\n"
+      "my_study_tiles_by_list = {'version': 'version-1', 'number_pixel_rows_for_tile': 256, 'number_pixel_columns_for_tile': 256, 'slides': {'Slide_0': {'filename': '/root/.cache/pooch/wsi/TCGA-AN-A0G0-01Z-00-DX1.svs', 'slide_name': 'TCGA-AN-A0G0-01Z-00-DX1', 'slide_group': 'Group 3', 'number_pixel_rows_for_chunk': 2048, 'number_pixel_columns_for_chunk': 2048, 'target_magnification': 20.0, 'scan_magnification': 40.0, 'read_magnification': 40.0, 'returned_magnification': 40.0, 'level': 8, 'number_pixel_rows_for_slide': 20572, 'number_pixel_columns_for_slide': 27607, 'tiles': {'tile_2912': {'tile_top': 5152, 'tile_left': 18592}, 'tile_6396': {'tile_top': 11648, 'tile_left': 0}, 'tile_6517': {'tile_top': 11648, 'tile_left': 27104}, 'tile_10782': {'tile_top': 19488, 'tile_left': 18144}, 'tile_10876': {'tile_top': 19712, 'tile_left': 11648}}}}}\n"
      ]
     }
    ],
@@ -489,14 +516,14 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "3cc6010e",
+   "id": "e120014f",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "my_study_tiles_randomly = {'version': 'version-1', 'number_pixel_rows_for_tile': 256, 'number_pixel_columns_for_tile': 256, 'slides': {'Slide_0': {'filename': '/root/.cache/pooch/wsi/TCGA-AN-A0G0-01Z-00-DX1.svs', 'slide_name': 'TCGA-AN-A0G0-01Z-00-DX1', 'slide_group': 'Group 3', 'number_pixel_rows_for_chunk': 2048, 'number_pixel_columns_for_chunk': 2048, 'target_magnification': 20.0, 'scan_magnification': 40.0, 'read_magnification': 40.0, 'returned_magnification': 40.0, 'level': 8, 'number_pixel_rows_for_slide': 20572, 'number_pixel_columns_for_slide': 27607, 'tiles': {'tile_0': {'tile_top': 10786, 'tile_left': 22964}, 'tile_1': {'tile_top': 7485, 'tile_left': 3533}, 'tile_2': {'tile_top': 19866, 'tile_left': 19454}, 'tile_3': {'tile_top': 15519, 'tile_left': 737}, 'tile_4': {'tile_top': 12588, 'tile_left': 16838}, 'tile_5': {'tile_top': 15907, 'tile_left': 619}, 'tile_6': {'tile_top': 214, 'tile_left': 16038}, 'tile_7': {'tile_top': 17510, 'tile_left': 13752}, 'tile_8': {'tile_top': 20204, 'tile_left': 26067}, 'tile_9': {'tile_top': 8053, 'tile_left': 42}}}}}\n"
+      "my_study_tiles_randomly = {'version': 'version-1', 'number_pixel_rows_for_tile': 256, 'number_pixel_columns_for_tile': 256, 'slides': {'Slide_0': {'filename': '/root/.cache/pooch/wsi/TCGA-AN-A0G0-01Z-00-DX1.svs', 'slide_name': 'TCGA-AN-A0G0-01Z-00-DX1', 'slide_group': 'Group 3', 'number_pixel_rows_for_chunk': 2048, 'number_pixel_columns_for_chunk': 2048, 'target_magnification': 20.0, 'scan_magnification': 40.0, 'read_magnification': 40.0, 'returned_magnification': 40.0, 'level': 8, 'number_pixel_rows_for_slide': 20572, 'number_pixel_columns_for_slide': 27607, 'tiles': {'tile_0': {'tile_top': 4641, 'tile_left': 5282}, 'tile_1': {'tile_top': 598, 'tile_left': 12915}, 'tile_2': {'tile_top': 18388, 'tile_left': 21249}, 'tile_3': {'tile_top': 13223, 'tile_left': 19118}, 'tile_4': {'tile_top': 13723, 'tile_left': 16106}, 'tile_5': {'tile_top': 5966, 'tile_left': 9924}, 'tile_6': {'tile_top': 6321, 'tile_left': 18795}, 'tile_7': {'tile_top': 14803, 'tile_left': 13870}, 'tile_8': {'tile_top': 15574, 'tile_left': 21991}, 'tile_9': {'tile_top': 9431, 'tile_left': 24373}}}}}\n"
      ]
     }
    ],
@@ -513,7 +540,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6f202811",
+   "id": "905bcb07",
    "metadata": {},
    "source": [
     "## Creating a TensorFlow Dataset\n",
@@ -524,7 +551,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "bf4df44c",
+   "id": "6618f2e1",
    "metadata": {},
    "outputs": [
     {
@@ -538,10 +565,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-03-23 14:34:06.844953: I tensorflow/core/platform/cpu_feature_guard.cc:151] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F FMA\n",
+      "2022-04-26 18:24:41.817040: I tensorflow/core/platform/cpu_feature_guard.cc:151] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F FMA\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2022-03-23 14:34:08.005244: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 9650 MB memory:  -> device: 0, name: GeForce RTX 2080 Ti, pci bus id: 0000:da:00.0, compute capability: 7.5\n",
-      "2022-03-23 14:34:08.007860: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:1 with 9650 MB memory:  -> device: 1, name: GeForce RTX 2080 Ti, pci bus id: 0000:db:00.0, compute capability: 7.5\n"
+      "2022-04-26 18:24:42.505833: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 9650 MB memory:  -> device: 0, name: GeForce RTX 2080 Ti, pci bus id: 0000:db:00.0, compute capability: 7.5\n"
      ]
     },
     {
@@ -576,7 +602,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c98ba65",
+   "id": "72421b0a",
    "metadata": {},
    "source": [
     "## Fetch a model for prediction\n",
@@ -591,7 +617,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "99c967fa",
+   "id": "dfbf1170",
    "metadata": {},
    "outputs": [
     {
@@ -608,25 +634,25 @@
      "text": [
       "Have /root/.cache/pooch/model/tcga_brca_model.unzip/tcga_brca_model.\n",
       "Downloading data from https://storage.googleapis.com/tensorflow/keras-applications/resnet/resnet50v2_weights_tf_dim_ordering_tf_kernels_notop.h5\n",
-      "94674944/94668760 [==============================] - 1s 0us/step\n",
-      "94683136/94668760 [==============================] - 1s 0us/step\n"
+      "94674944/94668760 [==============================] - 2s 0us/step\n",
+      "94683136/94668760 [==============================] - 2s 0us/step\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-03-23 14:34:46.387040: I tensorflow/stream_executor/cuda/cuda_dnn.cc:368] Loaded cuDNN version 8100\n",
-      "2022-03-23 14:34:57.929018: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'gradients/PartitionedCall_6_grad/PartitionedCall' has 3 outputs but the _output_shapes attribute specifies shapes for 33 outputs. Output shapes may be inaccurate.\n",
-      "2022-03-23 14:34:57.929101: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'gradients/PartitionedCall_4_grad/PartitionedCall' has 3 outputs but the _output_shapes attribute specifies shapes for 33 outputs. Output shapes may be inaccurate.\n",
-      "2022-03-23 14:34:57.929216: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'gradients/PartitionedCall_5_grad/PartitionedCall' has 3 outputs but the _output_shapes attribute specifies shapes for 33 outputs. Output shapes may be inaccurate.\n",
-      "2022-03-23 14:34:57.929252: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'gradients/PartitionedCall_2_grad/PartitionedCall' has 1 outputs but the _output_shapes attribute specifies shapes for 6 outputs. Output shapes may be inaccurate.\n",
-      "2022-03-23 14:34:57.929280: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'gradients/PartitionedCall_3_grad/PartitionedCall' has 1 outputs but the _output_shapes attribute specifies shapes for 6 outputs. Output shapes may be inaccurate.\n",
-      "2022-03-23 14:35:01.470280: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'PartitionedCall_2' has 2 outputs but the _output_shapes attribute specifies shapes for 6 outputs. Output shapes may be inaccurate.\n",
-      "2022-03-23 14:35:01.470361: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'PartitionedCall_3' has 2 outputs but the _output_shapes attribute specifies shapes for 6 outputs. Output shapes may be inaccurate.\n",
-      "2022-03-23 14:35:01.470392: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'PartitionedCall_4' has 1 outputs but the _output_shapes attribute specifies shapes for 11 outputs. Output shapes may be inaccurate.\n",
-      "2022-03-23 14:35:01.470437: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'PartitionedCall_5' has 1 outputs but the _output_shapes attribute specifies shapes for 11 outputs. Output shapes may be inaccurate.\n",
-      "2022-03-23 14:35:01.470462: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'PartitionedCall_6' has 1 outputs but the _output_shapes attribute specifies shapes for 11 outputs. Output shapes may be inaccurate.\n"
+      "2022-04-26 18:25:24.536937: I tensorflow/stream_executor/cuda/cuda_dnn.cc:368] Loaded cuDNN version 8400\n",
+      "2022-04-26 18:25:36.339473: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'gradients/PartitionedCall_6_grad/PartitionedCall' has 3 outputs but the _output_shapes attribute specifies shapes for 33 outputs. Output shapes may be inaccurate.\n",
+      "2022-04-26 18:25:36.339574: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'gradients/PartitionedCall_4_grad/PartitionedCall' has 3 outputs but the _output_shapes attribute specifies shapes for 33 outputs. Output shapes may be inaccurate.\n",
+      "2022-04-26 18:25:36.339629: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'gradients/PartitionedCall_5_grad/PartitionedCall' has 3 outputs but the _output_shapes attribute specifies shapes for 33 outputs. Output shapes may be inaccurate.\n",
+      "2022-04-26 18:25:36.339665: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'gradients/PartitionedCall_2_grad/PartitionedCall' has 1 outputs but the _output_shapes attribute specifies shapes for 6 outputs. Output shapes may be inaccurate.\n",
+      "2022-04-26 18:25:36.339697: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'gradients/PartitionedCall_3_grad/PartitionedCall' has 1 outputs but the _output_shapes attribute specifies shapes for 6 outputs. Output shapes may be inaccurate.\n",
+      "2022-04-26 18:25:39.837166: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'PartitionedCall_2' has 2 outputs but the _output_shapes attribute specifies shapes for 6 outputs. Output shapes may be inaccurate.\n",
+      "2022-04-26 18:25:39.837258: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'PartitionedCall_3' has 2 outputs but the _output_shapes attribute specifies shapes for 6 outputs. Output shapes may be inaccurate.\n",
+      "2022-04-26 18:25:39.837291: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'PartitionedCall_4' has 1 outputs but the _output_shapes attribute specifies shapes for 11 outputs. Output shapes may be inaccurate.\n",
+      "2022-04-26 18:25:39.837348: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'PartitionedCall_5' has 1 outputs but the _output_shapes attribute specifies shapes for 11 outputs. Output shapes may be inaccurate.\n",
+      "2022-04-26 18:25:39.837383: W tensorflow/core/common_runtime/graph_constructor.cc:803] Node 'PartitionedCall_6' has 1 outputs but the _output_shapes attribute specifies shapes for 11 outputs. Output shapes may be inaccurate.\n"
      ]
     },
     {
@@ -674,7 +700,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ddbf37d",
+   "id": "4614c2a3",
    "metadata": {},
    "source": [
     "## Make predictions"
@@ -683,7 +709,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "16e9124c",
+   "id": "b050a930",
    "metadata": {},
    "outputs": [
     {
@@ -691,8 +717,8 @@
      "output_type": "stream",
      "text": [
       "Starting predictions\n",
-      "Made 8019 predictions for 100 tiles in 12.370248794555664 s.\n",
-      "Average of 0.12370248794555665 s per tile.\n"
+      "Made 8168 predictions for 100 tiles in 12.364816904067993 s.\n",
+      "Average of 0.12364816904067993 s per tile.\n"
      ]
     }
    ],
@@ -714,7 +740,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3cea1d26",
+   "id": "09fc739b",
    "metadata": {},
    "source": [
     "## Look at internals"
@@ -723,7 +749,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "70937a12",
+   "id": "1144f373",
    "metadata": {},
    "outputs": [
     {
@@ -763,7 +789,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ecf793c4",
+   "id": "d492e513",
    "metadata": {},
    "source": [
     "## Display a tile"
@@ -772,13 +798,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "b59c56f2",
+   "id": "9531e48d",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dc549bf2e3b84d288434f2350f2702e0",
+       "model_id": "488d59d05f994efebaf3bc464a97150a",
        "version_major": 2,
        "version_minor": 0
       },


### PR DESCRIPTION
Google Colab complains that it cannot find `cudnn` when the TensorFlow model is instantiated.  I suspect that this is a versioning issue; maybe the default installed `cudnn` is not compatible with the latest version of `tensorflow-gpu` (which is currently 2.8.0).  Installing the latest `libcudnn8` and `libcudnn8-dev` fixes the problem.