### PR TITLE
ENH: Versions as strings, not numbers, so that 3.1 != 3.10, etc.

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
 
         include:
           - flake8-python-git-tag: "<4.0.0"
@@ -61,10 +61,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.9
+    - name: Set up Python "3.9"
       uses: actions/setup-python@v1
       with:
-        python-version: 3.9
+        python-version: "3.9"
     - name: Install pypa/build
       run: >-
         python -m pip install build --user

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/example/pytorch_stream.ipynb
+++ b/example/pytorch_stream.ipynb
@@ -1,0 +1,447 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "52afa009",
+   "metadata": {},
+   "source": [
+    "# Demonstration of histomics_stream\n",
+    "\n",
+    "Click to open in [[GitHub](https://github.com/DigitalSlideArchive/HistomicsStream/tree/master/example/pytorch.ipynb)] [[Google Colab](https://colab.research.google.com/github/DigitalSlideArchive/HistomicsStream/blob/master/example/pytorch_stream.ipynb)]\n",
+    "\n",
+    "The `histomics_stream` Python package sits at the start of any machine learning workflow that is built on the PyTorch machine learning library.  The package is responsible for efficient access to the input image data that will be used to fit a new machine learning model or will be used to predict regions of interest in novel inputs using an already learned model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04bf42bd",
+   "metadata": {},
+   "source": [
+    "## Installation\n",
+    "\n",
+    "If you are running this notebook on Google Colab or another system where `histomics_stream` and its dependencies are not yet installed then they can be installed with the following commands.  Note that image readers in addition to openslide are also supported by using, e.g., `large_image[openslide,ometiff,openjpeg,bioformats]` on the below pip install command line."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b7ee19a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get histomics_stream and its dependencies\n",
+    "!apt update\n",
+    "!apt install -y python3-openslide openslide-tools\n",
+    "!pip install 'large_image[openslide]' --find-links https://girder.github.io/large_image_wheels\n",
+    "!pip install histomics_stream\n",
+    "\n",
+    "# Get other packages used in this notebook\n",
+    "# N.B. itkwidgets works with jupyter<=3.0.0\n",
+    "!apt install libcudnn8 libcudnn8-dev\n",
+    "!pip install histomics_detect pooch itkwidgets\n",
+    "!jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-matplotlib jupyterlab-datawidgets itkwidgets\n",
+    "\n",
+    "print(\n",
+    "    \"\\nNOTE!: On Google Colab you may need to choose 'Runtime->Restart runtime' for these updates to take effect.\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0dc8f7db",
+   "metadata": {},
+   "source": [
+    "## Fetching and creating the test data\n",
+    "This notebook has demonstrations that use the files `TCGA-AN-A0G0-01Z-00-DX1.svs` (365 MB) and `TCGA-AN-A0G0-01Z-00-DX1.mask.png` (4 kB),  The pooch commands will fetch them if they are not already available."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4669d1a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pooch\n",
+    "\n",
+    "# download whole slide image\n",
+    "wsi_path = pooch.retrieve(\n",
+    "    fname=\"TCGA-AN-A0G0-01Z-00-DX1.svs\",\n",
+    "    url=\"https://northwestern.box.com/shared/static/qelyzb45bigg6sqyumtj8kt2vwxztpzm\",\n",
+    "    known_hash=\"d046f952759ff6987374786768fc588740eef1e54e4e295a684f3bd356c8528f\",\n",
+    "    path=str(pooch.os_cache(\"pooch\")) + os.sep + \"wsi\",\n",
+    ")\n",
+    "print(f\"Have {wsi_path}\")\n",
+    "\n",
+    "# download binary mask image\n",
+    "mask_path = pooch.retrieve(\n",
+    "    fname=\"TCGA-AN-A0G0-01Z-00-DX1.mask.png\",\n",
+    "    url=\"https://northwestern.box.com/shared/static/2q13q2r83avqjz9glrpt3s3nop6uhi2i\",\n",
+    "    known_hash=\"bb657ead9fd3b8284db6ecc1ca8a1efa57a0e9fd73d2ea63ce6053fbd3d65171\",\n",
+    "    path=str(pooch.os_cache(\"pooch\")) + os.sep + \"wsi\",\n",
+    ")\n",
+    "print(f\"Have {mask_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68668b27",
+   "metadata": {},
+   "source": [
+    "## Creating a study for use with histomics_stream\n",
+    "\n",
+    "We describe the input and desired parameters using standard Python lists and dictionaries.  Here we give a high-level configuration; selection of tiles is done subsequently.\n",
+    "\n",
+    "N.B.: __*all*__ values that are number of pixels are based upon the `target_magnification` that is supplied to `FindResolutionForSlide`.  This includes pixel sizes of a slide, chunk, or tile and it includes the pixel coordinates for a chunk or tile.  It applies whether the numbers are supplied to histomics_stream or returned by histomics_stream.  However, if the `magnification_source` is not `exact` the `returned_magnification` may not equal the `target_magnification`; to get the number of pixels that is relevant for the `returned_magnification`, typically these numbers of pixels are multiplied by the ratio `returned_magnification / target_magnification`.  In particular, the *pixel size of the returned tiles* will be the requested size times this ratio."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "39fd5e65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import histomics_stream as hs\n",
+    "import histomics_stream.pytorch\n",
+    "import torch\n",
+    "\n",
+    "# Create a study and insert study-wide information\n",
+    "my_study0 = {\"version\": \"version-1\"}\n",
+    "my_study0[\"number_pixel_rows_for_tile\"] = 256\n",
+    "my_study0[\"number_pixel_columns_for_tile\"] = 256\n",
+    "my_slides = my_study0[\"slides\"] = {}\n",
+    "\n",
+    "# Add a slide to the study, including slide-wide information with it.\n",
+    "my_slide0 = my_slides[\"Slide_0\"] = {}\n",
+    "my_slide0[\"filename\"] = wsi_path\n",
+    "my_slide0[\"slide_name\"] = \"TCGA-AN-A0G0-01Z-00-DX1\"\n",
+    "my_slide0[\"slide_group\"] = \"Group 3\"\n",
+    "my_slide0[\"number_pixel_rows_for_chunk\"] = 2048\n",
+    "my_slide0[\"number_pixel_columns_for_chunk\"] = 2048\n",
+    "\n",
+    "# For each slide, find the appropriate resolution given the target_magnification and\n",
+    "# magnification_tolerance.  In this example, we use the same parameters for each slide,\n",
+    "# but this is not required generally.\n",
+    "find_resolution_for_slide = hs.configure.FindResolutionForSlide(\n",
+    "    my_study0, target_magnification=20, magnification_source=\"native\"\n",
+    ")\n",
+    "for slide in my_study0[\"slides\"].values():\n",
+    "    find_resolution_for_slide(slide)\n",
+    "print(f\"my_study0 = {my_study0}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d428686",
+   "metadata": {},
+   "source": [
+    "## Tile selection\n",
+    "\n",
+    "We are going to demonstrate several approaches to choosing tiles.  Each approach will start with its own copy of the `my_study0` that we have built so far."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c8c09df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import copy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f184408",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Demonstrate TilesByGridAndMask without a mask\n",
+    "my_study_tiles_by_grid = copy.deepcopy(my_study0)\n",
+    "tiles_by_grid = hs.configure.TilesByGridAndMask(\n",
+    "    my_study_tiles_by_grid,\n",
+    "    number_pixel_overlap_rows_for_tile=32,\n",
+    "    number_pixel_overlap_columns_for_tile=32,\n",
+    "    randomly_select=5,\n",
+    ")\n",
+    "# We could apply this to a subset of the slides, but we will apply it to all slides in\n",
+    "# this example.\n",
+    "for slide in my_study_tiles_by_grid[\"slides\"].values():\n",
+    "    tiles_by_grid(slide)\n",
+    "print(f\"my_study_tiles_by_grid = {my_study_tiles_by_grid}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c7d6b16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Demonstrate TilesByGridAndMask with a mask\n",
+    "my_study_tiles_by_grid_and_mask = copy.deepcopy(my_study0)\n",
+    "tiles_by_grid_and_mask = hs.configure.TilesByGridAndMask(\n",
+    "    my_study_tiles_by_grid_and_mask,\n",
+    "    number_pixel_overlap_rows_for_tile=0,\n",
+    "    number_pixel_overlap_columns_for_tile=0,\n",
+    "    mask_filename=mask_path,\n",
+    "    randomly_select=10,\n",
+    ")\n",
+    "# We could apply this to a subset of the slides, but we will apply it to all slides in\n",
+    "# this example.\n",
+    "for slide in my_study_tiles_by_grid_and_mask[\"slides\"].values():\n",
+    "    tiles_by_grid_and_mask(slide)\n",
+    "print(f\"my_study_tiles_by_grid_and_mask = {my_study_tiles_by_grid_and_mask}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00c16959",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Demonstrate TilesByList\n",
+    "my_study_tiles_by_list = copy.deepcopy(my_study0)\n",
+    "tiles_by_list = hs.configure.TilesByList(\n",
+    "    my_study_tiles_by_list,\n",
+    "    randomly_select=5,\n",
+    "    tiles_dictionary=my_study_tiles_by_grid[\"slides\"][\"Slide_0\"][\"tiles\"],\n",
+    ")\n",
+    "# We could apply this to a subset of the slides, but we will apply it to all slides in\n",
+    "# this example.\n",
+    "for slide in my_study_tiles_by_list[\"slides\"].values():\n",
+    "    tiles_by_list(slide)\n",
+    "print(f\"my_study_tiles_by_list = {my_study_tiles_by_list}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f87bfd8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Demonstrate TilesRandomly\n",
+    "my_study_tiles_randomly = copy.deepcopy(my_study0)\n",
+    "tiles_randomly = hs.configure.TilesRandomly(my_study_tiles_randomly, randomly_select=10)\n",
+    "# We could apply this to a subset of the slides, but we will apply it to all slides in\n",
+    "# this example.\n",
+    "for slide in my_study_tiles_randomly[\"slides\"].values():\n",
+    "    tiles_randomly(slide)\n",
+    "print(f\"my_study_tiles_randomly = {my_study_tiles_randomly}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c733607e",
+   "metadata": {},
+   "source": [
+    "## Creating a Dataset\n",
+    "\n",
+    "We request tiles indicated by the mask and create a Dataset that has the image data for these tiles as well as associated parameters for each tile, such as its location."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f13156e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Demonstrate TilesByGridAndMask with a mask\n",
+    "my_study_of_tiles = copy.deepcopy(my_study0)\n",
+    "tiles_by_grid_and_mask = hs.configure.TilesByGridAndMask(\n",
+    "    my_study_of_tiles,\n",
+    "    number_pixel_overlap_rows_for_tile=0,\n",
+    "    number_pixel_overlap_columns_for_tile=0,\n",
+    "    mask_filename=mask_path,\n",
+    "    mask_threshold=0.5,\n",
+    "    randomly_select=100,\n",
+    ")\n",
+    "for slide in my_study_of_tiles[\"slides\"].values():\n",
+    "    tiles_by_grid_and_mask(slide)\n",
+    "print(\"Finished selecting tiles.\")\n",
+    "\n",
+    "create_pytorch_dataloader = hs.pytorch.CreateTorchDataloader()\n",
+    "tiles = create_pytorch_dataloader(my_study_of_tiles)\n",
+    "print(\"Finished with CreateTorchDataloader\")\n",
+    "print(f\"{type(tiles)=}\")\n",
+    "print(f\"{type(iter(tiles))=}\")\n",
+    "print(f\"{dir(tiles)=}\")\n",
+    "print(f\"{type(tiles.dataset)=}\")\n",
+    "print(f\"{type(tiles.dataset.__iter__())=}\")\n",
+    "tile_iter = iter(tiles)\n",
+    "tile = next(tile_iter)\n",
+    "print(f\"{type(tile)=}\")\n",
+    "print(f\"{len(tile)=}\")\n",
+    "print(f\"{type(tile[0])=}\")\n",
+    "print(f\"{type(tile[1])=}\")\n",
+    "# print(f\"{tile=}\")\n",
+    "# print(f\"... with tile shape = {tiles.take(1).get_single_element()[0][0].shape}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "535d5b93",
+   "metadata": {},
+   "source": [
+    "## Fetch a model for prediction\n",
+    "\n",
+    "We fetch a model (840 MB compressed, 1.3 GB decompressed) that we will use to make predictions.\n",
+    "\n",
+    "Because each element of our Dataset is a tuple `(rgb_image_data, dictionary_of_annotation)`, a typical model that accepts only the former as its input needs to be wrapped.\n",
+    "\n",
+    "Note that this model assumes that the tiles/images are not batched, with the understanding that if there is enough memory to do batching then one should instead choose a larger tile size. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e3cf69e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# download trained model.\n",
+    "model_path = pooch.retrieve(\n",
+    "    fname=\"tcga_brca_model\",\n",
+    "    url=\"https://northwestern.box.com/shared/static/4g6idrqlpvgxnsktz8pym5386njyvyb6\",\n",
+    "    known_hash=\"b5b5444cc8874d17811a89261abeafd9b9603e7891a8b2a98d8f13e2846a6689\",\n",
+    "    path=str(pooch.os_cache(\"pooch\")) + os.sep + \"model\",\n",
+    "    processor=pooch.Unzip(),\n",
+    ")\n",
+    "model_path = os.path.split(model_path[0])[0]\n",
+    "print(f\"Have {model_path}.\")\n",
+    "\n",
+    "# restore keras model\n",
+    "from histomics_detect.models import FasterRCNN\n",
+    "\n",
+    "model = tf.keras.models.load_model(\n",
+    "    model_path, custom_objects={\"FasterRCNN\": FasterRCNN}\n",
+    ")\n",
+    "\n",
+    "# Each element of the `tiles` tensorflow Dataset is a (rgb_image_data, dictionary_of_annotation) pair.\n",
+    "# Wrap the unwrapped_model so that it knows to use the image.\n",
+    "class WrappedModel(tf.keras.Model):\n",
+    "    def __init__(self, model, *args, **kwargs):\n",
+    "        super(WrappedModel, self).__init__(*args, **kwargs)\n",
+    "        self.model = model\n",
+    "\n",
+    "    def call(self, element):\n",
+    "        return (self.model(element[0]), element[1])\n",
+    "\n",
+    "\n",
+    "unwrapped_model = model\n",
+    "model = WrappedModel(unwrapped_model)\n",
+    "print(\"Model built and wrapped.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78e1530c",
+   "metadata": {},
+   "source": [
+    "## Make predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7c7ff58",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "print(\"Starting predictions\")\n",
+    "start_time = time.time()\n",
+    "# This model assumes that the tiles are not batched.  Do not use, e.g., tiles.batch(32).\n",
+    "predictions = model.predict(tiles)\n",
+    "end_time = time.time()\n",
+    "number_of_inputs = len([0 for tile in tiles])\n",
+    "number_of_predictions = predictions[0].shape[0]\n",
+    "print(\n",
+    "    f\"Made {number_of_predictions} predictions for {number_of_inputs} tiles in {end_time - start_time} s.\"\n",
+    ")\n",
+    "print(f\"Average of {(end_time - start_time) / number_of_inputs} s per tile.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b29db04d",
+   "metadata": {},
+   "source": [
+    "## Look at internals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f522902",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_element = tiles.take(1).get_single_element()\n",
+    "my_pair = my_element[0]\n",
+    "my_target = my_element[1]\n",
+    "my_weight = my_element[2]\n",
+    "my_image = my_pair[0]\n",
+    "my_annotation = my_pair[1]\n",
+    "\n",
+    "print(f\"   type(my_element) = {type(my_element)}\")\n",
+    "print(f\"    len(my_element) = {len(my_element)}\")\n",
+    "print(f\"      type(my_pair) = {type(my_pair)}\")\n",
+    "print(f\"       len(my_pair) = {len(my_pair)}\")\n",
+    "print(f\"    type(my_target) = {type(my_target)}\")\n",
+    "print(f\"    type(my_weight) = {type(my_weight)}\")\n",
+    "print(f\"     type(my_image) = {type(my_image)}\")\n",
+    "print(f\"     my_image.shape = {my_image.shape}\")\n",
+    "print(f\"type(my_annotation) = {type(my_annotation)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cbadfd84",
+   "metadata": {},
+   "source": [
+    "## Display a tile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1295089a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import itk, itkwidgets\n",
+    "\n",
+    "itkwidgets.view(itk.image_from_array(my_image.numpy(), is_vector=True))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "histomics_stream",
+   "language": "python",
+   "name": "histomics_stream"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/example/pytorch_stream.ipynb
+++ b/example/pytorch_stream.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "52afa009",
+   "id": "f87613a9",
    "metadata": {},
    "source": [
     "# Demonstration of histomics_stream\n",
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "04bf42bd",
+   "id": "a8490f25",
    "metadata": {},
    "source": [
     "## Installation\n",
@@ -25,7 +25,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7b7ee19a",
+   "id": "9f0162d7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0dc8f7db",
+   "id": "ed2efd66",
    "metadata": {},
    "source": [
     "## Fetching and creating the test data\n",
@@ -58,7 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4669d1a7",
+   "id": "b2ea3c60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "68668b27",
+   "id": "4274b5d6",
    "metadata": {},
    "source": [
     "## Creating a study for use with histomics_stream\n",
@@ -99,7 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39fd5e65",
+   "id": "7ed953a9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +125,7 @@
     "# magnification_tolerance.  In this example, we use the same parameters for each slide,\n",
     "# but this is not required generally.\n",
     "find_resolution_for_slide = hs.configure.FindResolutionForSlide(\n",
-    "    my_study0, target_magnification=20, magnification_source=\"native\"\n",
+    "    my_study0, target_magnification=20, magnification_source=\"exact\"\n",
     ")\n",
     "for slide in my_study0[\"slides\"].values():\n",
     "    find_resolution_for_slide(slide)\n",
@@ -134,7 +134,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d428686",
+   "id": "0fde9d2e",
    "metadata": {},
    "source": [
     "## Tile selection\n",
@@ -145,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c8c09df",
+   "id": "4ca79608",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,7 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f184408",
+   "id": "cba3ab43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4c7d6b16",
+   "id": "953ebb17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "00c16959",
+   "id": "f341e882",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f87bfd8",
+   "id": "9bc2770f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,7 +237,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c733607e",
+   "id": "e35fe040",
    "metadata": {},
    "source": [
     "## Creating a Dataset\n",
@@ -248,7 +248,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f13156e1",
+   "id": "0d272866",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,79 +269,116 @@
     "create_pytorch_dataloader = hs.pytorch.CreateTorchDataloader()\n",
     "tiles = create_pytorch_dataloader(my_study_of_tiles)\n",
     "print(\"Finished with CreateTorchDataloader\")\n",
-    "print(f\"{type(tiles)=}\")\n",
-    "print(f\"{type(iter(tiles))=}\")\n",
-    "print(f\"{dir(tiles)=}\")\n",
-    "print(f\"{type(tiles.dataset)=}\")\n",
-    "print(f\"{type(tiles.dataset.__iter__())=}\")\n",
-    "tile_iter = iter(tiles)\n",
-    "tile = next(tile_iter)\n",
-    "print(f\"{type(tile)=}\")\n",
-    "print(f\"{len(tile)=}\")\n",
-    "print(f\"{type(tile[0])=}\")\n",
-    "print(f\"{type(tile[1])=}\")\n",
-    "# print(f\"{tile=}\")\n",
+    "# print(f\"{tile = }\")\n",
     "# print(f\"... with tile shape = {tiles.take(1).get_single_element()[0][0].shape}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "535d5b93",
+   "id": "800f2502",
    "metadata": {},
    "source": [
     "## Fetch a model for prediction\n",
     "\n",
-    "We fetch a model (840 MB compressed, 1.3 GB decompressed) that we will use to make predictions.\n",
+    "We build a arbitrary but reasonable model for demonstration purposes.\n",
     "\n",
-    "Because each element of our Dataset is a tuple `(rgb_image_data, dictionary_of_annotation)`, a typical model that accepts only the former as its input needs to be wrapped.\n",
-    "\n",
-    "Note that this model assumes that the tiles/images are not batched, with the understanding that if there is enough memory to do batching then one should instead choose a larger tile size. "
+    "Because each element of our Dataset is a tuple `(rgb_image_data, dictionary_of_annotation)`, a typical model that accepts only the former as its input needs to be wrapped."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e3cf69e",
+   "id": "fd890cf5",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# download trained model.\n",
-    "model_path = pooch.retrieve(\n",
-    "    fname=\"tcga_brca_model\",\n",
-    "    url=\"https://northwestern.box.com/shared/static/4g6idrqlpvgxnsktz8pym5386njyvyb6\",\n",
-    "    known_hash=\"b5b5444cc8874d17811a89261abeafd9b9603e7891a8b2a98d8f13e2846a6689\",\n",
-    "    path=str(pooch.os_cache(\"pooch\")) + os.sep + \"model\",\n",
-    "    processor=pooch.Unzip(),\n",
+    "in_channels = 3\n",
+    "kernel_size = (5, 5)\n",
+    "number_of_categories = 2\n",
+    "# Use `padding` to preserve the image size when k is odd\n",
+    "padding = tuple(int((k - 1) // 2) for k in kernel_size)\n",
+    "print(f\"{in_channels = }\")\n",
+    "print(f'{my_study_tiles_randomly[\"number_pixel_rows_for_tile\"] = }')\n",
+    "print(f'{my_study_tiles_randomly[\"number_pixel_columns_for_tile\"] = }')\n",
+    "print(f\"{number_of_categories = }\")\n",
+    "\n",
+    "\n",
+    "class MyTorchModel(torch.nn.modules.module.Module):\n",
+    "    def __init__(\n",
+    "        self,\n",
+    "        in_channels,\n",
+    "        number_pixel_rows_for_tile,\n",
+    "        number_pixel_columns_for_tile,\n",
+    "        number_of_categories,\n",
+    "    ):\n",
+    "        super(MyTorchModel, self).__init__()\n",
+    "        out1_channels = 2 * in_channels\n",
+    "        self.conv1 = torch.nn.Conv2d(\n",
+    "            in_channels, out1_channels, kernel_size, padding=padding\n",
+    "        )\n",
+    "        out2_channels = 4 * in_channels\n",
+    "        self.conv2 = torch.nn.Conv2d(\n",
+    "            out1_channels, out2_channels, kernel_size, padding=padding\n",
+    "        )\n",
+    "        self.relu = torch.nn.ReLU()\n",
+    "        self.pool = torch.nn.MaxPool2d(2, 2)\n",
+    "        self.flat_size = int(\n",
+    "            in_channels\n",
+    "            * number_pixel_rows_for_tile\n",
+    "            * number_pixel_columns_for_tile\n",
+    "            / (out2_channels / in_channels)\n",
+    "        )\n",
+    "        self.fc1 = torch.nn.Linear(self.flat_size, 128)\n",
+    "        self.fc2 = torch.nn.Linear(128, number_of_categories)\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        x = self.pool(self.relu(self.conv1(x)))\n",
+    "        x = self.pool(self.relu(self.conv2(x)))\n",
+    "        x = x.view(-1, self.flat_size)\n",
+    "        x = self.relu(self.fc1(x))\n",
+    "        x = self.relu(self.fc2(x))\n",
+    "        return x\n",
+    "\n",
+    "\n",
+    "unwrapped_model = MyTorchModel(\n",
+    "    in_channels,\n",
+    "    my_study_tiles_randomly[\"number_pixel_rows_for_tile\"],\n",
+    "    my_study_tiles_randomly[\"number_pixel_columns_for_tile\"],\n",
+    "    number_of_categories,\n",
     ")\n",
-    "model_path = os.path.split(model_path[0])[0]\n",
-    "print(f\"Have {model_path}.\")\n",
     "\n",
-    "# restore keras model\n",
-    "from histomics_detect.models import FasterRCNN\n",
     "\n",
-    "model = tf.keras.models.load_model(\n",
-    "    model_path, custom_objects={\"FasterRCNN\": FasterRCNN}\n",
-    ")\n",
-    "\n",
-    "# Each element of the `tiles` tensorflow Dataset is a (rgb_image_data, dictionary_of_annotation) pair.\n",
-    "# Wrap the unwrapped_model so that it knows to use the image.\n",
-    "class WrappedModel(tf.keras.Model):\n",
+    "class WrapModel(torch.nn.modules.module.Module):\n",
     "    def __init__(self, model, *args, **kwargs):\n",
-    "        super(WrappedModel, self).__init__(*args, **kwargs)\n",
-    "        self.model = model\n",
+    "        super(WrapModel, self).__init__(*args, **kwargs)\n",
+    "        self.model = unwrapped_model\n",
     "\n",
-    "    def call(self, element):\n",
-    "        return (self.model(element[0]), element[1])\n",
+    "    # @staticmethod\n",
+    "    # class DataLoaderElement(torch.utils.data.DataLoader):\n",
+    "    #     def __init__(self, data_loader, index):\n",
+    "    #         self.data_loader = data_loader\n",
+    "    #         self.index = index\n",
+    "    #     def __iter__(self):\n",
+    "    #         self.iter = iter(data_loader)\n",
+    "    #         return self\n",
+    "    #     def __next__(self):\n",
+    "    #         return next(self.iter)\n",
+    "\n",
+    "    # def forward(self, x):\n",
+    "    #     p = self.model(self.DataLoaderElement(x, 0))\n",
+    "    #     return p, x[1]\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        p = self.model(x[0])\n",
+    "        return p, x[1]\n",
     "\n",
     "\n",
-    "unwrapped_model = model\n",
-    "model = WrappedModel(unwrapped_model)\n",
-    "print(\"Model built and wrapped.\")"
+    "print(\"Model created\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "78e1530c",
+   "id": "6e687409",
    "metadata": {},
    "source": [
     "## Make predictions"
@@ -350,28 +387,51 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e7c7ff58",
+   "id": "a64fc291",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import time\n",
+    "print(f\"{type(tiles) = }\")\n",
+    "tile_iter = iter(tiles)\n",
+    "print(f\"{type(tile_iter) = }\")\n",
+    "tile = next(tile_iter)\n",
+    "print(f\"{type(tile) = }\")\n",
+    "print(f\"{len(tile) = }\")\n",
+    "print(f\"{type(tile[0]) = }\")\n",
+    "print(f\"{tile[0].shape = }\")\n",
+    "print(f\"{type(tile[1]) = }\")\n",
+    "unwrapped_prediction = unwrapped_model(tile[0])\n",
+    "print(f\"{unwrapped_prediction = }\")\n",
+    "print(\"\")\n",
     "\n",
-    "print(\"Starting predictions\")\n",
-    "start_time = time.time()\n",
-    "# This model assumes that the tiles are not batched.  Do not use, e.g., tiles.batch(32).\n",
-    "predictions = model.predict(tiles)\n",
-    "end_time = time.time()\n",
-    "number_of_inputs = len([0 for tile in tiles])\n",
-    "number_of_predictions = predictions[0].shape[0]\n",
-    "print(\n",
-    "    f\"Made {number_of_predictions} predictions for {number_of_inputs} tiles in {end_time - start_time} s.\"\n",
-    ")\n",
-    "print(f\"Average of {(end_time - start_time) / number_of_inputs} s per tile.\")"
+    "model = WrapModel(unwrapped_model)\n",
+    "prediction = model(tile)\n",
+    "print(f\"{type(prediction) = }\")\n",
+    "print(f\"{len(prediction) = }\")\n",
+    "print(f\"{type(prediction[0]) = }\")\n",
+    "print(f\"{prediction[0] = }\")\n",
+    "print(f\"{type(prediction[1]) = }\")\n",
+    "print(\"\")\n",
+    "\n",
+    "unwrapped_predictions = [unwrapped_model(tile[0]) for tile in tiles]\n",
+    "print(f\"{type(unwrapped_predictions) = }\")\n",
+    "print(f\"{len(unwrapped_predictions) = }\")\n",
+    "print(f\"{type(unwrapped_predictions[0]) = }\")\n",
+    "print(f\"{unwrapped_predictions[0] = }\")\n",
+    "\n",
+    "predictions = [model(tile) for tile in tiles]\n",
+    "print(f\"{type(predictions) = }\")\n",
+    "print(f\"{len(predictions) = }\")\n",
+    "print(f\"{type(predictions[0]) = }\")\n",
+    "print(f\"{predictions[0] = }\")\n",
+    "\n",
+    "# predictions = model(tiles)\n",
+    "# print(f\"predictions computed\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b29db04d",
+   "id": "1f16b044",
    "metadata": {},
    "source": [
     "## Look at internals"
@@ -380,31 +440,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f522902",
+   "id": "c277a4c8",
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_element = tiles.take(1).get_single_element()\n",
-    "my_pair = my_element[0]\n",
-    "my_target = my_element[1]\n",
-    "my_weight = my_element[2]\n",
-    "my_image = my_pair[0]\n",
-    "my_annotation = my_pair[1]\n",
-    "\n",
-    "print(f\"   type(my_element) = {type(my_element)}\")\n",
-    "print(f\"    len(my_element) = {len(my_element)}\")\n",
-    "print(f\"      type(my_pair) = {type(my_pair)}\")\n",
-    "print(f\"       len(my_pair) = {len(my_pair)}\")\n",
-    "print(f\"    type(my_target) = {type(my_target)}\")\n",
-    "print(f\"    type(my_weight) = {type(my_weight)}\")\n",
-    "print(f\"     type(my_image) = {type(my_image)}\")\n",
-    "print(f\"     my_image.shape = {my_image.shape}\")\n",
-    "print(f\"type(my_annotation) = {type(my_annotation)}\")"
+    "print(f\"              type(tiles) = {type(tiles)}\")\n",
+    "print(f\"      type(tiles.dataset) = {type(tiles.dataset)}\")\n",
+    "print(f\"type(iter(tiles.dataset)) = {type(iter(tiles.dataset))}\")\n",
+    "print(f\"          type(tile_iter) = {type(tile_iter)}\")\n",
+    "print(f\"               type(tile) = {type(tile)}\")\n",
+    "print(f\"                len(tile) = {len(tile)}\")\n",
+    "print(f\"            type(tile[0]) = {type(tile[0])}\")\n",
+    "print(f\"            tile[0].shape = {tile[0].shape}\")\n",
+    "print(f\"            type(tile[1]) = {type(tile[1])}\")\n",
+    "print(f\"{tile[0][0,0,0,0].to(torch.float32) = }\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "cbadfd84",
+   "id": "5cd2372a",
    "metadata": {},
    "source": [
     "## Display a tile"
@@ -413,14 +467,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1295089a",
+   "id": "262e9ea1",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import itk, itkwidgets\n",
-    "\n",
-    "itkwidgets.view(itk.image_from_array(my_image.numpy(), is_vector=True))"
-   ]
+   "source": []
   }
  ],
  "metadata": {

--- a/example/tensorflow_stream.ipynb
+++ b/example/tensorflow_stream.ipynb
@@ -136,6 +136,7 @@
    ],
    "source": [
     "import histomics_stream as hs\n",
+    "import histomics_stream.tensorflow\n",
     "import tensorflow as tf\n",
     "\n",
     "# Create a study and insert study-wide information\n",

--- a/histomics_stream/__init__.py
+++ b/histomics_stream/__init__.py
@@ -1,3 +1,21 @@
+# =========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# =========================================================================
+
 """Whole-slide image streamer for machine learning frameworks."""
 
 __version__ = "2.2.5"

--- a/histomics_stream/__init__.py
+++ b/histomics_stream/__init__.py
@@ -1,10 +1,11 @@
-"""Whole-slide image streamer for TensorFlow."""
+"""Whole-slide image streamer for machine learning frameworks."""
 
 __version__ = "2.2.5"
 
 """
 
-This module supports efficient whole-slide reading and processing in a tensorflow graph.
+This module supports efficient whole-slide reading and processing for a machine learning
+execution graph.
 
 """
-from . import configure, tensorflow, codecs
+from . import configure, codecs

--- a/histomics_stream/__init__.py
+++ b/histomics_stream/__init__.py
@@ -1,6 +1,6 @@
 """Whole-slide image streamer for TensorFlow."""
 
-__version__ = "2.2.4"
+__version__ = "2.2.5"
 
 """
 

--- a/histomics_stream/codecs.py
+++ b/histomics_stream/codecs.py
@@ -1,3 +1,21 @@
+# =========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# =========================================================================
+
 """Whole-slide image streamer for machine learning frameworks.
 
 The histomics_stream.codecs module supplies codecs that are useful for Zarr file storage with jpeg or

--- a/histomics_stream/codecs.py
+++ b/histomics_stream/codecs.py
@@ -1,4 +1,4 @@
-"""Whole-slide image file reader for TensorFlow.
+"""Whole-slide image streamer for machine learning frameworks.
 
 The histomics_stream.codecs module supplies codecs that are useful for Zarr file storage with jpeg or
 jpeg2k compression.

--- a/histomics_stream/configure.py
+++ b/histomics_stream/configure.py
@@ -1,3 +1,21 @@
+# =========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# =========================================================================
+
 """Whole-slide image streamer for machine learning frameworks."""
 
 import copy
@@ -817,14 +835,13 @@ class TilesRandomly:
             tiles[f"tile_{number_of_tiles}"] = {"tile_top": row, "tile_left": column}
             number_of_tiles += 1
 
+
 class ChunkLocations:
     def __call__(self, study_description):
         """
         Given the list of desired tile locations, computes the locations of chunks to be
         read
         """
-
-        print("Calling new code: ChunkLocations.__call__")
 
         if not (
             "version" in study_description
@@ -952,3 +969,28 @@ class ChunkLocations:
                     max([tile["tile_left"] for tile in tiles.values()])
                     + number_pixel_columns_for_tile
                 )
+
+    def read_large_image(
+        self,
+        filename,
+        chunk_top,
+        chunk_left,
+        chunk_bottom,
+        chunk_right,
+        returned_magnification,
+    ):
+        import large_image
+
+        ts = large_image.open(filename)
+        chunk = ts.getRegion(
+            scale=dict(magnification=returned_magnification),
+            format=large_image.constants.TILE_FORMAT_NUMPY,
+            region=dict(
+                left=chunk_left,
+                top=chunk_top,
+                width=chunk_right - chunk_left,
+                height=chunk_bottom - chunk_top,
+                units="mag_pixels",
+            ),
+        )[0]
+        return chunk

--- a/histomics_stream/configure.py
+++ b/histomics_stream/configure.py
@@ -1,3 +1,5 @@
+"""Whole-slide image streamer for machine learning frameworks."""
+
 import copy
 import itk
 import math
@@ -818,8 +820,8 @@ class TilesRandomly:
 class ChunkLocations:
     def __call__(self, study_description):
         """
-        From scratch, creates a tensorflow dataset with one tensorflow
-        element per tile
+        Given the list of desired tile locations, computes the locations of chunks to be
+        read
         """
 
         print("Calling new code: ChunkLocations.__call__")

--- a/histomics_stream/configure.py
+++ b/histomics_stream/configure.py
@@ -281,9 +281,8 @@ class FindResolutionForSlide:
         slide["number_pixel_rows_for_slide"] = number_pixel_rows_for_slide
         slide["number_pixel_columns_for_slide"] = number_pixel_columns_for_slide
 
-    def _get_level_and_magnifications(
-        self, target_magnification, estimated_magnifications
-    ):
+    @staticmethod
+    def _get_level_and_magnifications(target_magnification, estimated_magnifications):
         """
         A private subroutine that computes level and magnifications.
         """
@@ -970,8 +969,8 @@ class ChunkLocations:
                     + number_pixel_columns_for_tile
                 )
 
+    @staticmethod
     def read_large_image(
-        self,
         filename,
         chunk_top,
         chunk_left,
@@ -994,3 +993,7 @@ class ChunkLocations:
             ),
         )[0]
         return chunk
+
+    @staticmethod
+    def scale_it(value, factor):
+        return math.floor(value / factor + 0.01)

--- a/histomics_stream/configure.py
+++ b/histomics_stream/configure.py
@@ -814,3 +814,139 @@ class TilesRandomly:
         for (row, column) in row_column_list:
             tiles[f"tile_{number_of_tiles}"] = {"tile_top": row, "tile_left": column}
             number_of_tiles += 1
+
+class ChunkLocations:
+    def __call__(self, study_description):
+        """
+        From scratch, creates a tensorflow dataset with one tensorflow
+        element per tile
+        """
+
+        print("Calling new code: ChunkLocations.__call__")
+
+        if not (
+            "version" in study_description
+            and study_description["version"] == "version-1"
+        ):
+            raise ValueError(
+                'study_description["version"] must exist and be equal to "version-1".'
+            )
+        if not (
+            "number_pixel_rows_for_tile" in study_description
+            and isinstance(study_description["number_pixel_rows_for_tile"], int)
+            and study_description["number_pixel_rows_for_tile"] > 0
+        ):
+            raise ValueError(
+                'study_description["number_pixel_rows_for_tile"]'
+                " must exist and be a positive integer"
+            )
+        if not (
+            "number_pixel_columns_for_tile" in study_description
+            and isinstance(study_description["number_pixel_columns_for_tile"], int)
+            and study_description["number_pixel_columns_for_tile"] > 0
+        ):
+            raise ValueError(
+                'study_description["number_pixel_columns_for_tile"]'
+                " must exist and be a positive integer"
+            )
+        for slide in study_description["slides"].values():
+            if not (
+                "returned_magnification" in slide
+                and isinstance(slide["returned_magnification"], (int, float))
+                and slide["returned_magnification"] > 0
+            ):
+                raise ValueError(
+                    'slide["returned_magnification"]'
+                    " must exist and be a positive number"
+                )
+        # Check that other necessary keys are also present!!!
+
+        # Partition the set of tiles into chunks.
+        self._designate_chunks_for_tiles(study_description)
+        # cProfile.runctx("self._designate_chunks_for_tiles(study_description)", globals=globals(), locals=locals(), sort="cumulative")
+        # print("_designate_chunks_for_tiles done")
+
+    def _designate_chunks_for_tiles(self, study_description):
+        number_pixel_rows_for_tile = study_description["number_pixel_rows_for_tile"]
+        number_pixel_columns_for_tile = study_description[
+            "number_pixel_columns_for_tile"
+        ]
+
+        for slide in study_description["slides"].values():
+            if not (
+                "number_pixel_rows_for_chunk" in slide
+                and isinstance(slide["number_pixel_rows_for_chunk"], int)
+                and slide["number_pixel_rows_for_chunk"] > 0
+            ):
+                raise ValueError(
+                    'slide["number_pixel_rows_for_chunk"]'
+                    " must exist and be a positive integer"
+                )
+            if not (
+                "number_pixel_columns_for_chunk" in slide
+                and isinstance(slide["number_pixel_columns_for_chunk"], int)
+                and slide["number_pixel_columns_for_chunk"] > 0
+            ):
+                raise ValueError(
+                    'slide["number_pixel_columns_for_chunk"]'
+                    " must exist and be a positive integer"
+                )
+            number_pixel_rows_for_chunk = slide["number_pixel_rows_for_chunk"]
+            number_pixel_columns_for_chunk = slide["number_pixel_columns_for_chunk"]
+
+            tiles_as_sorted_list = list(slide["tiles"].items())
+            tiles_as_sorted_list.sort(
+                key=lambda x: x[1]["tile_left"]
+            )  # second priority key
+            tiles_as_sorted_list.sort(
+                key=lambda x: x[1]["tile_top"]
+            )  # first priority key
+            chunks = slide["chunks"] = {}
+            number_of_chunks = 0
+            while len(tiles_as_sorted_list) > 0:
+                tile = tiles_as_sorted_list[0]
+                chunk = chunks[f"chunk_{number_of_chunks}"] = {
+                    "chunk_top": tile[1]["tile_top"],
+                    "chunk_left": tile[1]["tile_left"],
+                    "chunk_bottom": tile[1]["tile_top"] + number_pixel_rows_for_chunk,
+                    "chunk_right": tile[1]["tile_left"]
+                    + number_pixel_columns_for_chunk,
+                }
+                number_of_chunks += 1
+
+                # This implementation has a run time that is quadratic in the number of
+                # tiles that a slide has.  It is too slow; we should make it faster.
+                tiles = chunk["tiles"] = {}
+                subsequent_chunks = []
+                for tile in tiles_as_sorted_list:
+                    if (
+                        tile[1]["tile_top"] + number_pixel_rows_for_tile
+                        <= chunk["chunk_bottom"]
+                        and tile[1]["tile_left"] + number_pixel_columns_for_tile
+                        <= chunk["chunk_right"]
+                        and tile[1]["tile_left"] >= chunk["chunk_left"]
+                        and tile[1]["tile_top"] >= chunk["chunk_top"]
+                    ):
+                        tiles[tile[0]] = tile[1]
+                    else:
+                        subsequent_chunks.append(tile)
+
+                # Update the list of tiles that are not yet in chunks
+                tiles_as_sorted_list = subsequent_chunks
+
+                # Make the chunk as small as possible given the tiles that it must
+                # support.  Note that this also ensures that the pixels that are read do
+                # not run over the bottom or right border of the slide (assuming that
+                # the tiles do not go over those borders).
+                chunk["chunk_top"] = min([tile["tile_top"] for tile in tiles.values()])
+                chunk["chunk_left"] = min(
+                    [tile["tile_left"] for tile in tiles.values()]
+                )
+                chunk["chunk_bottom"] = (
+                    max([tile["tile_top"] for tile in tiles.values()])
+                    + number_pixel_rows_for_tile
+                )
+                chunk["chunk_right"] = (
+                    max([tile["tile_left"] for tile in tiles.values()])
+                    + number_pixel_columns_for_tile
+                )

--- a/histomics_stream/pytorch.py
+++ b/histomics_stream/pytorch.py
@@ -1,0 +1,67 @@
+# =========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# =========================================================================
+
+"""Whole-slide image streamer for machine learning frameworks."""
+
+"""
+See: How to load a list of numpy arrays to pytorch dataset loader?
+https://stackoverflow.com/questions/44429199/how-to-load-a-list-of-numpy-arrays-to-pytorch-dataset-loader
+
+torchvision.transforms.ToTensor transforms numpy array or PIL image to torch tensor
+torchvision.transforms.LongTensor maybe stacks tensors
+Subclassing torch.utils.data.Dataset maybe provides something like a tensorflow
+  dataset's interface
+Using a torch.utils.data.DataLoader on the torch.utils.data.Dataset subclass is maybe
+  like creating the actual dataset.
+"""
+
+"""
+See: A Comprehensive Guide to the DataLoader Class and Abstractions in PyTorch
+https://blog.paperspace.com/dataloaders-abstractions-pytorch/
+
+"""
+
+import numpy as np
+import torch
+
+from . import configure
+
+
+class MyDataset(torch.utils.data.Dataset):
+    def __init__(self):
+        """Store in self the data or pointers to it"""
+        pass                    # Write me!!!
+
+    def __getitem__(self, index):
+        """Return x, y, which is an (input, label) tuple"""
+        pass                    # Write me!!!
+
+    def __len__(self):
+        """Return the total number of data items that will be available"""
+        pass                    # Write me!!!
+
+
+class CreateTorchDataset(configure.ChunkLocations):
+    def __init__(self):
+        pass  # Write me!!!
+
+    def __call__(self, study_description):
+        """
+        From scratch, creates a torch dataset with one torch element per tile
+        """
+        pass  # Write me!!!

--- a/histomics_stream/tensorflow.py
+++ b/histomics_stream/tensorflow.py
@@ -1,3 +1,21 @@
+# =========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# =========================================================================
+
 """Whole-slide image streamer for machine learning frameworks."""
 
 import math
@@ -6,6 +24,7 @@ import re
 import tensorflow as tf
 
 from . import configure
+
 
 class CreateTensorFlowDataset(configure.ChunkLocations):
     def __init__(self):
@@ -16,8 +35,7 @@ class CreateTensorFlowDataset(configure.ChunkLocations):
 
     def __call__(self, study_description):
         """
-        From scratch, creates a tensorflow dataset with one tensorflow
-        element per tile
+        From scratch, creates a tensorflow dataset with one tensorflow element per tile
         """
 
         # Call to superclass to find the locations for the chunks
@@ -228,20 +246,15 @@ class CreateTensorFlowDataset(configure.ChunkLocations):
         chunk_right = math.floor(chunk_right.numpy() / factor.numpy() + 0.01)
         returned_magnification = returned_magnification.numpy()
 
-        import large_image
-
-        ts = large_image.open(filename)
-        chunk = ts.getRegion(
-            scale=dict(magnification=returned_magnification),
-            format=large_image.constants.TILE_FORMAT_NUMPY,
-            region=dict(
-                left=chunk_left,
-                top=chunk_top,
-                width=chunk_right - chunk_left,
-                height=chunk_bottom - chunk_top,
-                units="mag_pixels",
-            ),
-        )[0]
+        # Call to the superclass to get the pixel data for this chunk
+        chunk = self.read_large_image(
+            filename,
+            chunk_top,
+            chunk_left,
+            chunk_bottom,
+            chunk_right,
+            returned_magnification,
+        )
 
         # Do we want to support other than RGB and/or other than uint8?!!!
         return tf.convert_to_tensor(chunk[..., :3], dtype=tf.uint8)

--- a/histomics_stream/tensorflow.py
+++ b/histomics_stream/tensorflow.py
@@ -1,3 +1,5 @@
+"""Whole-slide image streamer for machine learning frameworks."""
+
 import math
 import numpy as np
 import re

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "imagecodecs",
     "itk",
     "numpy",
-    "tensorflow",
     "zarr",
 ]
 dynamic = ["version", "description"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,10 @@ maintainers = [{name = "Lee A. Newberg", email = "lee.newberg@kitware.com"}]
 keywords = ["tensorflow", "whole slide image", "stream", "machine learning"]
 classifiers = ["License :: OSI Approved :: Apache Software License"]
 dependencies = [
-    # tensorflow is not listed as a dependency because the user
-    # will likely want to specify the version for compatibility
-    # with the CUDA libraries, presence of GPUs, etc.
     "imagecodecs",
     "itk",
     "numpy",
+    "tensorflow",
     "zarr",
 ]
 dynamic = ["version", "description"]

--- a/test/test_create_study.py
+++ b/test/test_create_study.py
@@ -18,15 +18,15 @@
 #
 # =========================================================================
 
-import copy
-import histomics_stream as hs
 
-
-def test_histomics_stream_can_be_found():
+def test_create_study():
     """
-    Purpose: Exercise the basic steps for creating a tensorflow
-    Dataset
+    Purpose: Exercise the basic steps for creating a study dict, which is the precursor
+    step to creating a dataset/dataloader for a machine learning framework such as
+    TensorFlow or Torch.
     """
+    import copy
+    import histomics_stream as hs
 
     # Create a study and insert study-wide information
     my_study0 = {"version": "version-1"}
@@ -113,3 +113,10 @@ def test_histomics_stream_can_be_found():
     # in this example.
     for slide in my_study_tiles_randomly["slides"].values():
         tiles_randomly(slide)
+
+    # The next step would be creating a dataset/dataloader for a machine learning
+    # framework such as TensorFlow or Torch.  However, we will not do that in this test.
+
+
+if __name__ == "__main__":
+    test_create_study()

--- a/test/test_create_tensorflow_dataset.py
+++ b/test/test_create_tensorflow_dataset.py
@@ -1,18 +1,22 @@
 #!/usr/bin/env python3
 
-# Copyright NumFOCUS
+# =========================================================================
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+#   Copyright NumFOCUS
 #
-#        http://www.apache.org/licenses/LICENSE-2.0.txt
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# =========================================================================
 
 import copy
 import histomics_stream as hs

--- a/test/test_find_itk.py
+++ b/test/test_find_itk.py
@@ -1,18 +1,22 @@
 #!/usr/bin/env python3
 
-# Copyright NumFOCUS
+# =========================================================================
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+#   Copyright NumFOCUS
 #
-#        http://www.apache.org/licenses/LICENSE-2.0.txt
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# =========================================================================
 
 
 def test_itk_can_be_found():

--- a/test/test_find_itk.py
+++ b/test/test_find_itk.py
@@ -24,3 +24,7 @@ def test_itk_can_be_found():
 
     # Import succeeds
     import itk
+
+
+if __name__ == "__main__":
+    test_itk_can_be_found()


### PR DESCRIPTION
Re-writes version numbers as strings rather than as numbers in .github/workflows/*.yml files because 3.1 != 3.10, etc. Nothing is broken at present but in the future as, e.g., a Python version goes from 3.8 to 3.9 to 3.10, this could end up being an unexpected problem.