### PR TITLE
PERF: Memory and runtime improvements

### DIFF
--- a/histomics_stream/tensorflow.py
+++ b/histomics_stream/tensorflow.py
@@ -18,9 +18,9 @@
 
 """Whole-slide image streamer for machine learning frameworks."""
 
+import datetime
 import math
 import tensorflow as tf
-
 from . import configure
 
 
@@ -32,133 +32,143 @@ class CreateTensorFlowDataset(configure.ChunkLocations):
             "deterministic": False,
         }
 
-    def __call__(self, study_description):
+    def __call__(self, study_description, num_workers=1, worker_index=0):
         """
         From scratch, creates a tensorflow dataset with one tensorflow element per tile
         """
 
         # Call to superclass to find the locations for the chunks
+        # print(f"Build chunks: begin {datetime.datetime.now()}")
         configure.ChunkLocations.__call__(self, study_description)
+        # print(f"Build chunks: end {datetime.datetime.now()}")
 
-        # Start converting our description into tensors.
-        study_as_tensors = {
-            study_key: [tf.convert_to_tensor(study_description[study_key])]
-            for study_key in study_description.keys()
-            if study_key != "slides"
-        }
-        # print("study_as_tensors done")
-
-        chunk_list = list()
-        for slide_description in study_description["slides"].values():
-            slide_as_tensors = {
-                **study_as_tensors,
+        # Build one record for each chunk
+        _singular = {"tiles_top": "tile_top", "tiles_left": "tile_left"}
+        # print(f"Build chunk_list_by_row: begin {datetime.datetime.now()}")
+        chunk_list_by_row = [
+            {
                 **{
-                    slide_key: [tf.convert_to_tensor(slide_description[slide_key])]
-                    for slide_key in slide_description.keys()
-                    if slide_key not in ["tiles", "chunks"]
+                    key: value
+                    for key, value in study_description.items()
+                    if key != "slides"
+                },
+                **{
+                    key: value
+                    for key, value in slide_description.items()
+                    if key not in ("tiles", "chunks")
+                },
+                **{
+                    key: value
+                    for key, value in chunk_description.items()
+                    if key != "tiles"
+                },
+                **{
+                    key: [
+                        tile_description[_singular[key]]
+                        for tile_description in chunk_description["tiles"].values()
+                    ]
+                    for key in ("tiles_top", "tiles_left")
                 },
             }
+            for slide_description in study_description["slides"].values()
+            for chunk_description in slide_description["chunks"].values()
+        ]
+        # print(f"Build chunk_list_by_row: end {datetime.datetime.now()}")
 
-            for chunk_description in slide_description["chunks"].values():
-                chunk_as_tensors = {
-                    **slide_as_tensors,
-                    **{
-                        chunk_key: [tf.convert_to_tensor(chunk_description[chunk_key])]
-                        for chunk_key in chunk_description.keys()
-                        if chunk_key != "tiles"
-                    },
-                    "tiles_top": [
-                        tf.convert_to_tensor(
-                            [
-                                tile["tile_top"]
-                                for tile in chunk_description["tiles"].values()
-                            ]
-                        )
-                    ],
-                    "tiles_left": [
-                        tf.convert_to_tensor(
-                            [
-                                tile["tile_left"]
-                                for tile in chunk_description["tiles"].values()
-                            ]
-                        )
-                    ],
-                }
+        if False:
 
-                # Make a tensorflow Dataset from this chunk.
-                chunk_dataset = tf.data.Dataset.from_tensor_slices(chunk_as_tensors)
-                chunk_list.append(chunk_dataset)
+            def gen():
+                for row in chunk_list_by_row:
+                    yield {
+                        key: (
+                            tf.constant
+                            if key not in ("tiles_top", "tiles_left")
+                            else tf.ragged.constant
+                        )([value])
+                        for key, value in row.items()
+                    }
 
-        study_dataset = self._concatenate_list(chunk_list)
-        del chunk_list
+            # This approach is not used because TensorFlow is rejecting output_signature
+            # = study_dataset.element_spec (and variations thereof).
+            output_signature = {
+                "version": tf.TensorSpec(shape=(), dtype=tf.string),
+                "tile_width": tf.TensorSpec(shape=(), dtype=tf.int32),
+                "tile_height": tf.TensorSpec(shape=(), dtype=tf.int32),
+                "overlap_height": tf.TensorSpec(shape=(), dtype=tf.int32),
+                "overlap_width": tf.TensorSpec(shape=(), dtype=tf.int32),
+                "filename": tf.TensorSpec(shape=(), dtype=tf.string),
+                "slide_name": tf.TensorSpec(shape=(), dtype=tf.string),
+                "slide_group": tf.TensorSpec(shape=(), dtype=tf.string),
+                "target_magnification": tf.TensorSpec(shape=(), dtype=tf.float32),
+                "scan_magnification": tf.TensorSpec(shape=(), dtype=tf.float32),
+                "read_magnification": tf.TensorSpec(shape=(), dtype=tf.float32),
+                "returned_magnification": tf.TensorSpec(shape=(), dtype=tf.float64),
+                "level": tf.TensorSpec(shape=(), dtype=tf.int32),
+                "slide_width": tf.TensorSpec(shape=(), dtype=tf.int32),
+                "slide_height": tf.TensorSpec(shape=(), dtype=tf.int32),
+                "chunk_height": tf.TensorSpec(shape=(), dtype=tf.int32),
+                "chunk_width": tf.TensorSpec(shape=(), dtype=tf.int32),
+                "slide_height_tiles": tf.TensorSpec(shape=(), dtype=tf.int32),
+                "slide_width_tiles": tf.TensorSpec(shape=(), dtype=tf.int32),
+                "chunk_top": tf.TensorSpec(shape=(), dtype=tf.int32),
+                "chunk_left": tf.TensorSpec(shape=(), dtype=tf.int32),
+                "chunk_bottom": tf.TensorSpec(shape=(), dtype=tf.int32),
+                "chunk_right": tf.TensorSpec(shape=(), dtype=tf.int32),
+                "tiles_top": tf.RaggedTensorSpec(
+                    tf.TensorShape([None]), tf.int32, 0, tf.int64
+                ),
+                "tiles_left": tf.RaggedTensorSpec(
+                    tf.TensorShape([None]), tf.int32, 0, tf.int64
+                ),
+            }
+            study_dataset = tf.data.Dataset.from_generator(gen, output_signature)
+        else:
+            # print(f"Build chunk_list_by_column: begin {datetime.datetime.now()}")
+            chunk_list_by_column = {
+                key: (
+                    tf.constant
+                    if key not in ("tiles_top", "tiles_left")
+                    else tf.ragged.constant
+                )([chunk[key] for chunk in chunk_list_by_row])
+                for key in chunk_list_by_row[0].keys()
+            }
+            # print(f"Build chunk_list_by_column: end {datetime.datetime.now()}")
+
+            del chunk_list_by_row
+            # print(f"Build study_dataset from_tensor_slices: begin {datetime.datetime.now()}")
+            study_dataset = tf.data.Dataset.from_tensor_slices(chunk_list_by_column)
+            # print(f"Build study_dataset from_tensor_slices: end {datetime.datetime.now()}")
+            del chunk_list_by_column
+
+            # print(f"{study_dataset.element_spec = }")
+
+        # Shard the dataset
+        if num_workers != 1 or worker_index != 0:
+            study_dataset = study_dataset.shard(num_workers, worker_index)
 
         # We have accumulated the chunk datasets into a study_dataset where each element
         # is a chunk.  Read in the chunk pixel data and split it into tiles.
+        # print(f"Build study_dataset map: begin {datetime.datetime.now()}")
         study_dataset = study_dataset.map(
             self._read_and_split_chunk, **self.dataset_map_options
         )
-        # print("_read_and_split_chunk done")
+        # print(f"Build study_dataset map: end {datetime.datetime.now()}")
+
         # Change study_dataset so that each element is a tile.
         study_dataset = study_dataset.unbatch()
-        # print("unbatch done")
 
         # Make the tile pixels easier to find in each study_dataset element.  Also, tack
         # on additional elements to the tuple so that the form is (inputs, targets,
         # sample_weights).
+        # print(f"Build study_dataset pop: begin {datetime.datetime.now()}")
         study_dataset = study_dataset.map(
-            lambda elem: ((elem.pop("tile_pixels"), elem), None, None),
-            **self.dataset_map_options,
+            lambda elem: ((elem.pop("tile_pixels"), elem),), **self.dataset_map_options
         )
-        # print("elem.pop done")
+        study_dataset = study_dataset.map(
+            lambda elem: (elem, None, None), **self.dataset_map_options
+        )
+        # print(f"Build study_dataset pop: end {datetime.datetime.now()}")
         return study_dataset
-
-    def _concatenate_list(self, dataset_list):
-        # We will need to call tf.Dataset.concatenate multiple times to combine all the
-        # datasets in this list.  In theory, we have several options.
-
-        # #1) We can scan the list from start to end and append each dataset as we
-        # encounter it.  This means that the concatenate calls will be left-heavy; each
-        # will have many datasets on the left, but only one dataset on the right.
-        #     response = None
-        #     for dataset in dataset_list:
-        #         if response is None:
-        #             response = dataset
-        #         else:
-        #             response = response.concatenate(dataset)
-        #     return response
-
-        # #2) We can scan the list from end to start and pre-pend each dataset as we
-        # encouter it.  This means that the concatenate calls will be right-heavy; they
-        # will have many datasets on the right, but only one dataset on the left.
-        #     response = None
-        #     for dataset in reversed(dataset_list):
-        #         if response is None:
-        #             response = dataset
-        #         else:
-        #             response = dataset.concatenate(response)
-        #     return response
-
-        # #3) We can do a recursive, divide-and-conquer approach so that each
-        # concatenate call will have approximately equally many datasets on the left and
-        # right.
-        length = len(dataset_list)
-        if length == 1:
-            return dataset_list[0]
-        if length > 1:
-            return self._concatenate_list(dataset_list[0 : length // 2]).concatenate(
-                self._concatenate_list(dataset_list[length // 2 : length])
-            )
-        return None
-        # We chose the divide-and-conquer approach because it should work most
-        # generally.  The downside of the left-heavy approach is that finding the first
-        # dataset requires descending through all concatenate calls.  This can overload
-        # system resources at the time of a predict(combined_dataset) call and kill the
-        # process.  The right-heavy approach does not have this problem unless there is
-        # some sort of aggressive shuffling going on, in which case many resources could
-        # be required to find a single dataset.  The balanced, divide-and-conquer
-        # approach should work well even with shuffling, though it could be a little
-        # slower than the right-heavy approach in the case of predicting the datasets in
-        # a simple forward order.
 
     @tf.function
     def _read_and_split_chunk(self, elem):
@@ -170,7 +180,7 @@ class CreateTensorFlowDataset(configure.ChunkLocations):
             elem["returned_magnification"], dtype=tf.float32
         )
         chunk_as_tensor = tf.py_function(
-            func=self._py_read_chunk,
+            func=CreateTensorFlowDataset._py_read_chunk,
             inp=[
                 elem["chunk_top"],
                 elem["chunk_left"],
@@ -266,10 +276,11 @@ class CreateTensorFlowDataset(configure.ChunkLocations):
             "tile_left": elem["tiles_left"],
             "tile_pixels": tiles,
         }
+
         return response
 
+    @staticmethod
     def _py_read_chunk(
-        self,
         chunk_top,
         chunk_left,
         chunk_bottom,
@@ -291,7 +302,7 @@ class CreateTensorFlowDataset(configure.ChunkLocations):
         returned_magnification = returned_magnification.numpy()
 
         # Call to the superclass to get the pixel data for this chunk
-        chunk = self.read_large_image(
+        chunk = configure.ChunkLocations.read_large_image(
             filename,
             chunk_top,
             chunk_left,


### PR DESCRIPTION
This includes several bundled performance improvements:
PERF: Use N log N approach for collating tiles into chunks instead of N^2
PERF: Use `large_image_source_tiff` to read a chunk from disk instead of `large_image`
PERF: More efficiently create input to `tf.data.Dataset.from_tensor_slices` rather than from multiple `dataset` objects
PERF: Support `num_workers` and `worker_index` for sharding in `CreateTensorFlowDataset`
PERF: Make `_py_read_chunk` be `@staticmethod`

The collating of tiles into chunks takes 14s instead of 175s on the example I tested with.

I don't see anything controversial here and will merge it in 24 hours if I hear no objections.