### PR TITLE
BUG: Slide height and width confusion

### DIFF
--- a/histomics_stream/__init__.py
+++ b/histomics_stream/__init__.py
@@ -18,7 +18,7 @@
 
 """Whole-slide image streamer for machine learning frameworks."""
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 
 """
 

--- a/histomics_stream/configure.py
+++ b/histomics_stream/configure.py
@@ -35,13 +35,13 @@ class _TilesByCommon:
         self._key_mapping = {
             "number_pixel_columns_for_chunk": "chunk_width",
             "number_pixel_columns_for_mask": "mask_width",
-            "number_pixel_columns_for_slide": "slide_height",
+            "number_pixel_columns_for_slide": "slide_width",
             "number_pixel_columns_for_tile": "tile_width",
             "number_pixel_overlap_columns_for_tile": "tile_overlap_width",
             "number_pixel_overlap_rows_for_tile": "tile_overlap_height",
             "number_pixel_rows_for_chunk": "chunk_height",
             "number_pixel_rows_for_mask": "mask_height",
-            "number_pixel_rows_for_slide": "slide_width",
+            "number_pixel_rows_for_slide": "slide_height",
             "number_pixel_rows_for_tile": "tile_height",
             "number_tile_columns_for_slide": "slide_width_tiles",
             "number_tile_rows_for_slide": "slide_height_tiles",
@@ -98,7 +98,7 @@ class FindResolutionForSlide(_TilesByCommon):
 
     An instance of class FindResolutionForSlide is a callable that will add level,
     target_magnification, scan_magnification, read_magnification,
-    returned_magnification, slide_width, and slide_height fields to a slide dictionary.
+    returned_magnification, slide_height, and slide_width fields to a slide dictionary.
 
     Parameters for the constructor
     ------------------------------


### PR DESCRIPTION
The translations if old dictionary keys to new dictionary keys:

* from `number_pixel_columns_for_slide` to `slide_width`
* from `number_pixel_rows_for_slide` to `slide_height`

were swapped.  Fixed.

Also
ENH: Bump version to 2.3.1