### PR TITLE
Use (int, np.integer) in isinstance

### DIFF
--- a/histomics_stream/configure.py
+++ b/histomics_stream/configure.py
@@ -757,7 +757,7 @@ class TilesByList(_TilesByCommon):
             )
             and all(
                 [
-                    isinstance(tile_corner[key], int)
+                    isinstance(tile_corner[key], (int, np.integer))
                     for tile_corner in tiles_dictionary.values()
                     for key in ("tile_top", "tile_left")
                 ]


### PR DESCRIPTION
@Leengit This is an odd issue I came across with more details [here](https://stackoverflow.com/questions/37726830/how-to-determine-if-a-number-is-any-type-of-int-core-or-numpy-signed-or-not).

Should I apply this to other `isinstance(x, int)` checks with user-provided values too? Numpy types will be common.