### PR TITLE
ENH: Return `level` as type `int` if it is very close to an integer

### DIFF
--- a/histomics_stream/configure.py
+++ b/histomics_stream/configure.py
@@ -322,7 +322,8 @@ class FindResolutionForSlide(_TilesByCommon):
                     "in Zarr storage."
                 )
 
-        slide["level"] = level
+        int_level = int(round(level))
+        slide["level"] = int_level if abs(level - int_level) < 1e-4 else level
         # Note that slide size is defined by the requested magnification, which may not
         # be the same as the magnification for the selected level.  To get the slide
         # size for the magnification that we are using, these values must later be


### PR DESCRIPTION
When `large_image` is asked to return tiles with an `"exact"` magnification it may end up using a `level` (in the sense that `large_image` defines it) that is a non-integer.  (Also, a non-integer value of `level` might occur if the stored `"native"` magnifications are different by something other than powers of two.)  However, if that level is within `1e-6` of an integer we will return it as type `int` rather than type `float`.

@cooperlab if it would be better to round to the integer value but leave it as type `float`, please let me know.

Closes #95.