### PR TITLE
Arrange imports with `isort`

### DIFF
--- a/example/performance-EfficientNetV2S.py
+++ b/example/performance-EfficientNetV2S.py
@@ -16,12 +16,15 @@
 #
 # =========================================================================
 
-import histomics_stream as hs
-import histomics_stream.tensorflow
 import os
+import time
+
 import pooch
 import tensorflow as tf
-import time
+
+import histomics_stream as hs
+import histomics_stream.tensorflow
+
 
 """
 This is a script that is used to make timings of histomics_stream.  To some extent, it

--- a/example/performance-EfficientNet_V2_S_Weights.IMAGENET1K_V1.py
+++ b/example/performance-EfficientNet_V2_S_Weights.IMAGENET1K_V1.py
@@ -17,14 +17,17 @@
 # =========================================================================
 
 import argparse
-import histomics_stream as hs
-import histomics_stream.pytorch
 import itertools
 import os
-import pooch
 import time
+
+import pooch
 import torch
 import torchvision
+
+import histomics_stream as hs
+import histomics_stream.pytorch
+
 
 """
 This is a script that is used to make timings of histomics_stream.  To some extent, it

--- a/example/performance-detection.py
+++ b/example/performance-detection.py
@@ -16,12 +16,15 @@
 #
 # =========================================================================
 
-import histomics_stream as hs
-import histomics_stream.tensorflow
 import os
+import time
+
 import pooch
 import tensorflow as tf
-import time
+
+import histomics_stream as hs
+import histomics_stream.tensorflow
+
 
 """
 This is a script that is used to make timings of histomics_stream.  To some extent, it

--- a/example/performance-mnist.py
+++ b/example/performance-mnist.py
@@ -16,13 +16,16 @@
 #
 # =========================================================================
 
-import histomics_stream as hs
-import histomics_stream.tensorflow
 import os
+import time
+
 import pooch
 import tensorflow as tf
 import tensorflow_datasets as tfds
-import time
+
+import histomics_stream as hs
+import histomics_stream.tensorflow
+
 
 """
 This is a script that is used to make timings of histomics_stream.  To some extent, it

--- a/histomics_stream/codecs.py
+++ b/histomics_stream/codecs.py
@@ -23,9 +23,9 @@ with jpeg or jpeg2k compression.
 
 """
 
-from imagecodecs import jpeg_encode, jpeg_decode, jpeg2k_encode, jpeg2k_decode
+from imagecodecs import jpeg2k_decode, jpeg2k_encode, jpeg_decode, jpeg_encode
 from numcodecs.abc import Codec
-from numcodecs.compat import ensure_ndarray, ensure_contiguous_ndarray, ndarray_copy
+from numcodecs.compat import ensure_contiguous_ndarray, ensure_ndarray, ndarray_copy
 from numcodecs.registry import register_codec
 
 

--- a/histomics_stream/configure.py
+++ b/histomics_stream/configure.py
@@ -20,14 +20,15 @@
 
 import copy
 import itertools
-import itk
-import large_image
-import large_image_source_tiff
 import math
-import numpy as np
 import os
 import random
 import re
+
+import itk
+import large_image
+import large_image_source_tiff
+import numpy as np
 import scipy.interpolate
 
 
@@ -184,13 +185,15 @@ class FindResolutionForSlide(_TilesByCommon):
 
         # Do the work.
         if not re.compile(r"\.zarr$").search(filename):
-            
+
             # create large_image, prioritizing tiff source over openslide
             try:
                 import large_image_source_tiff
+
                 ts = large_image_source_tiff.open(filename)
             except:
                 import large_image
+
                 ts = large_image.open(filename)
 
             # scan_magnification = highest available magnification from source
@@ -442,16 +445,12 @@ class TilesByGridAndMask(_TilesByCommon):
         overlap_height = (
             kwargs["overlap_height"]
             if "overlap_height" in kwargs
-            else study["overlap_height"]
-            if "overlap_height" in study
-            else 0
+            else study["overlap_height"] if "overlap_height" in study else 0
         )
         overlap_width = (
             kwargs["overlap_width"]
             if "overlap_width" in kwargs
-            else study["overlap_width"]
-            if "overlap_width" in study
-            else 0
+            else study["overlap_width"] if "overlap_width" in study else 0
         )
 
         # Check values.
@@ -1151,16 +1150,20 @@ class ChunkLocations(_TilesByCommon):
             # Process this internal node
             means = subtree["means"]
             recurse = dict(
-                (qkey, self._find_in_range_and_delete(qvalue))
-                if all(
-                    (
-                        self.maxs[col] > means[col]
-                        if qkey & 2 ** (self.data.shape[1] - 1 - col)
-                        else self.mins[col] < means[col]
-                        for col in range(self.data.shape[1])
+                (
+                    (qkey, self._find_in_range_and_delete(qvalue))
+                    if all(
+                        (
+                            (
+                                self.maxs[col] > means[col]
+                                if qkey & 2 ** (self.data.shape[1] - 1 - col)
+                                else self.mins[col] < means[col]
+                            )
+                            for col in range(self.data.shape[1])
+                        )
                     )
+                    else (qkey, (self.no_indices, qvalue))
                 )
-                else (qkey, (self.no_indices, qvalue))
                 for qkey, qvalue in subtree["quadrants"].items()
             )
             indices = np.array(

--- a/histomics_stream/pytorch.py
+++ b/histomics_stream/pytorch.py
@@ -20,7 +20,9 @@
 
 import numpy as np
 import torch
+
 from . import configure
+
 
 """
 See: How to load a list of numpy arrays to pytorch dataset loader?

--- a/histomics_stream/tensorflow.py
+++ b/histomics_stream/tensorflow.py
@@ -19,7 +19,9 @@
 """Whole-slide image streamer for machine learning frameworks."""
 
 import math
+
 import tensorflow as tf
+
 from . import configure
 
 


### PR DESCRIPTION
Arrange the order of Python `import` statements with `isort` and then format them with `black -C`.