### PR TITLE
COMP: Give GitHub actions "id-token: write" permissions

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -63,6 +63,8 @@ jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-20.04
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@master
     - name: Set up Python "3.9"


### PR DESCRIPTION
An error reply from GitHub actions suggests that these permissions be added.